### PR TITLE
Parsing performance

### DIFF
--- a/src/read/pdb/parser.rs
+++ b/src/read/pdb/parser.rs
@@ -589,7 +589,7 @@ fn add_bonds(pdb: &mut PDB, bonds: Vec<(Context, LexItem)>) -> Vec<PDBError> {
                 let find = |atom: (String, isize, Option<String>, String)| {
                     pdb.chains()
                         .find(|c| c.id() == atom.3)
-                        .map(|c| {
+                        .and_then(|c| {
                             c.residues()
                                 .find(|r| {
                                     r.serial_number() == atom.1
@@ -601,7 +601,6 @@ fn add_bonds(pdb: &mut PDB, bonds: Vec<(Context, LexItem)>) -> Vec<PDBError> {
                                     })
                                 })
                         })
-                        .flatten()
                         .flatten()
                         .flatten()
                 };

--- a/src/structs/atom.rs
+++ b/src/structs/atom.rs
@@ -330,8 +330,7 @@ impl Atom {
     /// number is higher than 96.
     pub fn atomic_radius(&self) -> Option<f64> {
         self.atomic_number()
-            .map(reference_tables::get_atomic_radius)
-            .flatten()
+            .and_then(reference_tables::get_atomic_radius)
     }
 
     /// Get the van der Waals radius for this Atom in Å. The radius is defined up to element 'Es' or atomic number 99.
@@ -342,8 +341,7 @@ impl Atom {
     /// number is higher than 99.
     pub fn vanderwaals_radius(&self) -> Option<f64> {
         self.atomic_number()
-            .map(reference_tables::get_vanderwaals_radius)
-            .flatten()
+            .and_then(reference_tables::get_vanderwaals_radius)
     }
 
     /// Gets the covalent bond radii for this Atom.
@@ -472,13 +470,11 @@ impl Atom {
     ///
     /// It fails if for any one of the two atoms the radius (`atom.atomic_radius()`) is not defined.
     pub fn overlaps(&self, other: &Atom) -> Option<bool> {
-        self.atomic_radius()
-            .map(|self_rad| {
-                other
-                    .atomic_radius()
-                    .map(|other_rad| self.distance(other) <= self_rad + other_rad)
-            })
-            .flatten()
+        self.atomic_radius().and_then(|self_rad| {
+            other
+                .atomic_radius()
+                .map(|other_rad| self.distance(other) <= self_rad + other_rad)
+        })
     }
 
     /// Checks if this Atom overlaps with the given atom. It overlaps if the distance between the atoms is
@@ -492,13 +488,11 @@ impl Atom {
     ///
     /// It fails if for any one of the two atoms the radius (`atom.atomic_radius()`) is not defined.
     pub fn overlaps_wrapping(&self, other: &Atom, cell: &UnitCell) -> Option<bool> {
-        self.atomic_radius()
-            .map(|self_rad| {
-                other
-                    .atomic_radius()
-                    .map(|other_rad| self.distance_wrapping(other, cell) <= self_rad + other_rad)
-            })
-            .flatten()
+        self.atomic_radius().and_then(|self_rad| {
+            other
+                .atomic_radius()
+                .map(|other_rad| self.distance_wrapping(other, cell) <= self_rad + other_rad)
+        })
     }
 
     /// Checks if this Atom overlaps with the given atom. It overlaps if the distance between the atoms is
@@ -509,13 +503,11 @@ impl Atom {
     ///
     /// It fails if for any one of the two atoms the radius (`atom.covalent_bond_radii()`) is not defined.
     pub fn overlaps_bound(&self, other: &Atom) -> Option<bool> {
-        self.covalent_bond_radii()
-            .map(|self_rad| {
-                other
-                    .covalent_bond_radii()
-                    .map(|other_rad| self.distance(other) <= self_rad.0 + other_rad.0)
-            })
-            .flatten()
+        self.covalent_bond_radii().and_then(|self_rad| {
+            other
+                .covalent_bond_radii()
+                .map(|other_rad| self.distance(other) <= self_rad.0 + other_rad.0)
+        })
     }
 
     /// Checks if this Atom overlaps with the given atom. It overlaps if the distance between the atoms is
@@ -529,13 +521,11 @@ impl Atom {
     ///
     /// It fails if for any one of the two atoms the radius (`atom.covalent_bond_radii()`) is not defined.
     pub fn overlaps_bound_wrapping(&self, other: &Atom, cell: &UnitCell) -> Option<bool> {
-        self.covalent_bond_radii()
-            .map(|self_rad| {
-                other.covalent_bond_radii().map(|other_rad| {
-                    self.distance_wrapping(other, cell) <= self_rad.0 + other_rad.0
-                })
-            })
-            .flatten()
+        self.covalent_bond_radii().and_then(|self_rad| {
+            other
+                .covalent_bond_radii()
+                .map(|other_rad| self.distance_wrapping(other, cell) <= self_rad.0 + other_rad.0)
+        })
     }
 }
 

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -202,13 +202,12 @@ impl<'a> Model {
                     }
                 })
                 .ok()
-                .map(|index| {
+                .and_then(|index| {
                     self.chain(index)
                         .unwrap()
                         .binary_find_atom(serial_number, insertion_code)
                         .map(|h| h.extend(self.chain(index).unwrap()))
                 })
-                .flatten()
         }
     }
 
@@ -245,14 +244,13 @@ impl<'a> Model {
                     }
                 })
                 .ok()
-                .map(move |index| {
+                .and_then(move |index| {
                     let chain: *mut Chain = self.chain_mut(index).unwrap();
                     self.chain_mut(index)
                         .unwrap()
                         .binary_find_atom_mut(serial_number, insertion_code)
                         .map(|h| h.extend(chain))
                 })
-                .flatten()
         }
     }
 
@@ -264,8 +262,7 @@ impl<'a> Model {
         self.chains()
             .map(move |c| (c, search.clone().add_chain_info(c)))
             .filter(|(_c, search)| !matches!(search, Search::Known(false)))
-            .map(move |(c, search)| c.find(search).map(move |h| h.extend(c)))
-            .flatten()
+            .flat_map(move |(c, search)| c.find(search).map(move |h| h.extend(c)))
     }
 
     /// Find all hierarchies matching the given information
@@ -279,11 +276,10 @@ impl<'a> Model {
                 (c, search)
             })
             .filter(|(_c, search)| !matches!(search, Search::Known(false)))
-            .map(move |(c, search)| {
+            .flat_map(move |(c, search)| {
                 let c_ptr: *mut Chain = c;
                 c.find_mut(search).map(move |h| h.extend(c_ptr))
             })
-            .flatten()
     }
 
     /// Get the list of Chains making up this Model.

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -435,13 +435,10 @@ impl<'a> PDB {
         serial_number: usize,
         alternative_location: Option<&str>,
     ) -> Option<AtomConformerResidueChainModel<'a>> {
-        self.models()
-            .next()
-            .map(|m| {
-                m.binary_find_atom(serial_number, alternative_location)
-                    .map(|res| res.extend(m))
-            })
-            .flatten()
+        self.models().next().and_then(|m| {
+            m.binary_find_atom(serial_number, alternative_location)
+                .map(|res| res.extend(m))
+        })
     }
 
     /// Get the specified atom, its uniqueness is guaranteed by including the
@@ -454,14 +451,11 @@ impl<'a> PDB {
         serial_number: usize,
         alternative_location: Option<&str>,
     ) -> Option<AtomConformerResidueChainModelMut<'a>> {
-        self.models_mut()
-            .next()
-            .map(|m| {
-                let model: *mut Model = m;
-                m.binary_find_atom_mut(serial_number, alternative_location)
-                    .map(|res| res.extend(model))
-            })
-            .flatten()
+        self.models_mut().next().and_then(|m| {
+            let model: *mut Model = m;
+            m.binary_find_atom_mut(serial_number, alternative_location)
+                .map(|res| res.extend(model))
+        })
     }
 
     /// Find all hierarchies matching the given search. For more details see [Search].
@@ -482,8 +476,7 @@ impl<'a> PDB {
         self.models()
             .map(move |m| (m, search.clone().add_model_info(m)))
             .filter(|(_m, search)| !matches!(search, Search::Known(false)))
-            .map(move |(m, search)| m.find(search).map(move |h| h.extend(m)))
-            .flatten()
+            .flat_map(move |(m, search)| m.find(search).map(move |h| h.extend(m)))
     }
 
     /// Find all hierarchies matching the given information
@@ -497,11 +490,10 @@ impl<'a> PDB {
                 (m, search)
             })
             .filter(|(_m, search)| !matches!(search, Search::Known(false)))
-            .map(move |(m, search)| {
+            .flat_map(move |(m, search)| {
                 let m_ptr: *mut Model = m;
                 m.find_mut(search).map(move |h| h.extend(m_ptr))
             })
-            .flatten()
     }
 
     /// Get the list of Models making up this PDB.

--- a/src/structs/residue.rs
+++ b/src/structs/residue.rs
@@ -237,11 +237,10 @@ impl<'a> Residue {
         self.conformers()
             .map(move |c| (c, search.clone().add_conformer_info(c)))
             .filter(|(_c, search)| !matches!(search, Search::Known(false)))
-            .map(move |(c, search)| {
+            .flat_map(move |(c, search)| {
                 c.find(search)
                     .map(move |a| hierarchy::AtomConformer::new(a, c))
             })
-            .flatten()
     }
 
     /// Find all hierarchies matching the given information
@@ -255,12 +254,11 @@ impl<'a> Residue {
                 (c, search)
             })
             .filter(|(_c, search)| !matches!(search, Search::Known(false)))
-            .map(move |(c, search)| {
+            .flat_map(move |(c, search)| {
                 let c_ptr: *mut Conformer = c;
                 c.find_mut(search)
                     .map(move |a| hierarchy::AtomConformerMut::new(a, c_ptr))
             })
-            .flatten()
     }
 
     /// Get the list of conformers making up this Residue.


### PR DESCRIPTION
In `chain.rs` the residues are now iterated over in reverse order so the loop will be broken out of earlier. This leads to a significant performance gain during parsing.
Also some clippy lints
#81 