### PR TITLE
hacky workaround for using set membership check when adding new atoms

### DIFF
--- a/src/read/mmcif/parser.rs
+++ b/src/read/mmcif/parser.rs
@@ -3,6 +3,7 @@ use crate::error::*;
 use crate::structs::*;
 use crate::validate::*;
 use crate::StrictnessLevel;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::prelude::*;
 
@@ -369,6 +370,7 @@ fn parse_atoms(input: &Loop, pdb: &mut PDB) -> Option<Vec<PDBError>> {
                 chain_name,
                 (residue_number, insertion_code),
                 (residue_name, alt_loc),
+                &HashSet::new(),
             );
         } else {
             errors.push(PDBError::new(

--- a/src/read/pdb/parser.rs
+++ b/src/read/pdb/parser.rs
@@ -8,6 +8,7 @@ use crate::StrictnessLevel;
 
 use std::cmp;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -61,6 +62,7 @@ where
     let mut chain_iter = ('A'..='Z').cycle();
     // Initialize chain_id value
     let mut chain_id_new = chain_iter.next();
+    let mut residue_set = HashSet::new();
 
     for (mut linenumber, read_line) in input.lines().enumerate() {
         linenumber += 1; // 1 based indexing in files
@@ -119,6 +121,11 @@ where
                             .to_string();
                     }
 
+                    residue_set.insert((
+                        residue_serial_number + residue_serial_addition,
+                        insertion_code.clone(),
+                    ));
+
                     current_model.add_atom(
                         Atom::new(
                             hetero,
@@ -140,6 +147,7 @@ where
                             insertion_code.as_deref(),
                         ),
                         (&residue_name, alt_loc.as_deref()),
+                        &residue_set,
                     );
                     last_residue_serial_number = residue_serial_number;
                     last_atom_serial_number = serial_number;

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -381,25 +381,48 @@ impl<'a> Chain {
         new_atom: Atom,
         residue_id: (isize, Option<&str>),
         conformer_id: (&str, Option<&str>),
+        residue_set: &HashSet<(isize, Option<String>)>,
     ) {
-        let mut found = false;
+        // let mut found = false;
         let mut new_residue = Residue::new(residue_id.0, residue_id.1, None)
             .expect("Invalid chars in Residue creation");
         let mut current_residue = &mut new_residue;
-        for residue in &mut self.residues.iter_mut().rev() {
-            if residue.id() == residue_id {
-                current_residue = residue;
-                found = true;
-                break;
-            }
-        }
+
         #[allow(clippy::unwrap_used)]
-        if !found {
+        if residue_set
+            .get(&(
+                current_residue.serial_number(),
+                current_residue.insertion_code().map(|s| s.to_owned()),
+            ))
+            .is_some()
+        {
+            for residue in &mut self.residues.iter_mut().rev() {
+                if residue.id() == residue_id {
+                    current_residue = residue;
+                    break;
+                }
+            }
+        } else {
             self.residues.push(new_residue);
             current_residue = self.residues.last_mut().unwrap();
         }
 
         current_residue.add_atom(new_atom, conformer_id);
+
+        // for residue in &mut self.residues.iter_mut().rev() {
+        //     if residue.id() == residue_id {
+        //         current_residue = residue;
+        //         found = true;
+        //         break;
+        //     }
+        // }
+        // #[allow(clippy::unwrap_used)]
+        // if !found {
+        //     self.residues.push(new_residue);
+        //     current_residue = self.residues.last_mut().unwrap();
+        // }
+
+        // current_residue.add_atom(new_atom, conformer_id);
     }
 
     /// Add a Residue to the end of to the list of Residues making up this Chain. This does not detect any duplicates of names or serial numbers in the list of Residues.
@@ -529,6 +552,7 @@ impl<'a> Chain {
     }
 }
 
+use std::collections::HashSet;
 use std::fmt;
 impl fmt::Display for Chain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -394,7 +394,7 @@ impl<'a> Chain {
                 current_residue.serial_number(),
                 current_residue.insertion_code().map(|s| s.to_owned()),
             ))
-            .is_some()
+            .is_none()
         {
             for residue in &mut self.residues.iter_mut().rev() {
                 if residue.id() == residue_id {

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -412,12 +412,13 @@ impl<'a> Model {
         chain_id: &str,
         residue_id: (isize, Option<&str>),
         conformer_id: (&str, Option<&str>),
+        residue_set: &HashSet<(isize, Option<String>)>,
     ) {
         let mut found = false;
         let mut new_chain =
             Chain::new(chain_id.trim()).expect("Invalid characters in chain creation");
         let mut current_chain = &mut new_chain;
-        for chain in &mut self.chains {
+        for chain in &mut self.chains.iter_mut().rev() {
             if chain.id() == chain_id.trim() {
                 current_chain = chain;
                 found = true;
@@ -431,7 +432,7 @@ impl<'a> Model {
             current_chain = (&mut self.chains).last_mut().unwrap();
         }
 
-        current_chain.add_atom(new_atom, residue_id, conformer_id);
+        current_chain.add_atom(new_atom, residue_id, conformer_id, residue_set);
     }
 
     /// Add a Chain to the list of Chains making up this Model. This does not detect any duplicates of names or serial numbers in the list of Chains.
@@ -578,6 +579,7 @@ impl<'a> Model {
     }
 }
 
+use std::collections::HashSet;
 use std::fmt;
 impl fmt::Display for Model {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -660,6 +662,7 @@ mod tests {
             "A",
             (0, None),
             ("ALA", None),
+            &HashSet::new(),
         );
         // Test if changing properties for each element of the hierarchy is possible
         for mut hierarchy in a.atoms_with_hierarchy_mut() {

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -988,6 +988,8 @@ impl Default for PDB {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     #[test]
@@ -995,8 +997,8 @@ mod tests {
         let a = Atom::new(false, 0, "", 0.0, 0.0, 0.0, 0.0, 0.0, "", 0).unwrap();
         let b = Atom::new(false, 1, "", 0.0, 0.0, 0.0, 0.0, 0.0, "", 0).unwrap();
         let mut model = Model::new(0);
-        model.add_atom(b, "A", (0, None), ("LYS", None));
-        model.add_atom(a, "A", (0, None), ("LYS", None));
+        model.add_atom(b, "A", (0, None), ("LYS", None), &HashSet::new());
+        model.add_atom(a, "A", (0, None), ("LYS", None), &HashSet::new());
         let mut pdb = PDB::new();
         pdb.add_model(model);
         assert_eq!(pdb.atom(0).unwrap().serial_number(), 1);
@@ -1014,18 +1016,21 @@ mod tests {
             "A",
             (0, None),
             ("MET", Some("A")),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 1.0, 0.0, 0.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", Some("B")),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 2.0, 0.0, 0.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         let mut pdb = PDB::new();
         pdb.add_model(model);
@@ -1045,18 +1050,21 @@ mod tests {
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 1.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 2, "", 0.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         let mut pdb = PDB::new();
         pdb.add_model(model);
@@ -1089,18 +1097,21 @@ mod tests {
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 1.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 2, "", 0.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "B",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         let mut pdb = PDB::new();
         pdb.add_model(model);
@@ -1141,18 +1152,21 @@ mod tests {
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 1.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 2, "", 0.0, 1.0, 1.0, 0.0, 0.0, "", 0).unwrap(),
             "B",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         let pdb = PDB::new();
 
@@ -1170,18 +1184,21 @@ mod tests {
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 1, "", 1.0, 2.0, -1.0, 0.0, 0.0, "", 0).unwrap(),
             "A",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         model.add_atom(
             Atom::new(false, 2, "", 2.0, -1.0, 0.5, 0.0, 0.0, "", 0).unwrap(),
             "B",
             (0, None),
             ("MET", None),
+            &HashSet::new(),
         );
         let mut pdb = PDB::new();
         pdb.add_model(model);

--- a/tests/read_write_pdbs.rs
+++ b/tests/read_write_pdbs.rs
@@ -1,4 +1,5 @@
 use pdbtbx::*;
+use std::collections::HashSet;
 use std::path::Path;
 use std::time::Instant;
 use std::{env, fs};
@@ -158,7 +159,7 @@ fn save_pdb_strict() {
 
     let atom = Atom::new(false, 0, "H", 0.0, 0.0, 0.0, 0.0, 0.0, "H", 0).unwrap();
     let mut model = Model::new(0);
-    model.add_atom(atom, "A", (0, None), ("LYS", None));
+    model.add_atom(atom, "A", (0, None), ("LYS", None), &HashSet::new());
     let mut pdb = PDB::new();
     pdb.add_model(model);
 
@@ -180,7 +181,7 @@ fn save_mmcif_strict() {
 
     let atom = Atom::new(false, 0, "H", 0.0, 0.0, 0.0, 0.0, 0.0, "H", 0).unwrap();
     let mut model = Model::new(0);
-    model.add_atom(atom, "A", (0, None), ("LYS", None));
+    model.add_atom(atom, "A", (0, None), ("LYS", None), &HashSet::new());
     let mut pdb = PDB::new();
     pdb.add_model(model);
 


### PR DESCRIPTION
Fixes #81 
I hacked together a very dirty workaround for the performance issue with traversing the Residues.
This should not be merged obviously but I wanted to provide a proof of concept. It does not work for mmCIFs and breaks the tests and examples.
The main idea is to circumvent the issues that arise when using some sort of `Set` for storing Atoms/Residues etc. and instead create a `HashSet` on the side that holds the Residue ID that were already parsed into the PDB struct.
Whenever a new Atom is added a membership check is first performed so the existing Residues are only traversed (in reverse order) if this returns nothing.
I did a quick profiling and this seems to remove the bottleneck of `add_atom` pretty thoroughly.
Thoughts on the concept?

Edit: I checked with that ghastly 1HTQ PDB file and with the change I made, it takes ~3 seconds to parse it.