### PR TITLE
lazystatic for storing Residue and Chain ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rstar = { version = "^0.9.2", optional = true}
 serde = { version = "~1.0", optional = true, features = ["derive"] }
 rayon = {version = "^1", optional = true}
 doc-cfg = "0.1"
+lazy_static = "*"
 
 [dev-dependencies]
 serde_json = "~1.0"

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -59,8 +59,7 @@ fn main() {
     let val_and_c = pdb
         .conformers()
         .filter(|c| c.name() == "VAL")
-        .map(|c| c.atoms().filter(|a| a.element() == "C"))
-        .flatten()
+        .flat_map(|c| c.atoms().filter(|a| a.element() == "C"))
         .count();
     assert_eq!(pdb.find(search).count(), val_and_c);
 
@@ -78,14 +77,12 @@ fn main() {
     let val = pdb
         .conformers()
         .filter(|c| c.name() == "VAL")
-        .map(|c| c.atoms())
-        .flatten()
+        .flat_map(|c| c.atoms())
         .count();
     let c_not_val = pdb
         .conformers()
         .filter(|c| c.name() != "VAL")
-        .map(|c| c.atoms().filter(|a| a.element() == "C"))
-        .flatten()
+        .flat_map(|c| c.atoms().filter(|a| a.element() == "C"))
         .count();
     assert_eq!(pdb.find(search).count(), val + c_not_val);
 
@@ -103,14 +100,12 @@ fn main() {
     let val_not_c = pdb
         .conformers()
         .filter(|c| c.name() == "VAL")
-        .map(|c| c.atoms().filter(|a| a.element() != "C"))
-        .flatten()
+        .flat_map(|c| c.atoms().filter(|a| a.element() != "C"))
         .count();
     let c_not_val = pdb
         .conformers()
         .filter(|c| c.name() != "VAL")
-        .map(|c| c.atoms().filter(|a| a.element() == "C"))
-        .flatten()
+        .flat_map(|c| c.atoms().filter(|a| a.element() == "C"))
         .count();
     assert_eq!(pdb.find(search).count(), val_not_c + c_not_val);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,9 @@ println!("There are {} backbone atoms within 3.5Aͦ of the atom at index 42", to
 #![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(feature = "unstable-doc-cfg", feature(doc_cfg))]
 
+#[macro_use]
+extern crate lazy_static;
+
 /// To save and display errors
 mod error;
 /// To open PDB files

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -382,7 +382,6 @@ impl<'a> Chain {
         residue_id: (isize, Option<&str>),
         conformer_id: (&str, Option<&str>),
     ) {
-        // let mut found = false;
         let mut new_residue = Residue::new(residue_id.0, residue_id.1, None)
             .expect("Invalid chars in Residue creation");
         let mut current_residue = &mut new_residue;
@@ -397,7 +396,6 @@ impl<'a> Chain {
             for residue in &mut self.residues.iter_mut().rev() {
                 if residue.id() == residue_id {
                     current_residue = residue;
-                    // found = true;
                     break;
                 }
             }
@@ -407,21 +405,6 @@ impl<'a> Chain {
             current_residue = self.residues.last_mut().unwrap();
         }
 
-        // for residue in &mut self.residues.iter_mut().rev() {
-        //     if residue.id() == residue_id {
-        //         current_residue = residue;
-        //         found = true;
-        //         break;
-        //     }
-        // }
-        // #[allow(clippy::unwrap_used)]
-        // if !found {
-        //     self.residues.push(new_residue);
-        //     current_residue = self.residues.last_mut().unwrap();
-        // }
-
-        // println!("{:?}", CHAIN_RES_IN_PDB.chain_set.lock().unwrap());
-        // println!("{:?}", CHAIN_RES_IN_PDB.residue_set.lock().unwrap());
         current_residue.add_atom(new_atom, conformer_id);
     }
 

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -407,6 +407,9 @@ impl<'a> Chain {
                     break;
                 }
             }
+        } else {
+            self.residues.push(new_residue);
+            current_residue = self.residues.last_mut().unwrap();
         }
 
         // for residue in &mut self.residues.iter_mut().rev() {

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -413,7 +413,6 @@ impl<'a> Model {
         residue_id: (isize, Option<&str>),
         conformer_id: (&str, Option<&str>),
     ) {
-        // let mut found = false;
         let chain_id_trim = chain_id.trim();
         let mut new_chain =
             Chain::new(chain_id_trim).expect("Invalid characters in chain creation");
@@ -426,7 +425,6 @@ impl<'a> Model {
             for chain in &mut self.chains.iter_mut().rev() {
                 if chain.id() == chain_id_trim {
                     current_chain = chain;
-                    // found = true;
                     break;
                 }
             }
@@ -435,21 +433,6 @@ impl<'a> Model {
             self.chains.push(new_chain);
             current_chain = (&mut self.chains).last_mut().unwrap();
         }
-
-        // for chain in &mut self.chains.iter_mut().rev() {
-        //     if chain.id() == chain_id_trim {
-        //         current_chain = chain;
-        //         found = true;
-        //         break;
-        //     }
-        // }
-
-        // #[allow(clippy::unwrap_used)]
-        // if !found {
-        //     // As this moves the chain the atom should be added later to keep the reference intact
-        //     self.chains.push(new_chain);
-        //     current_chain = (&mut self.chains).last_mut().unwrap();
-        // }
 
         current_chain.add_atom(new_atom, residue_id, conformer_id);
     }

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -422,7 +422,7 @@ impl<'a> Model {
         let mut chain_set = CHAIN_RES_IN_PDB.chain_set.lock().unwrap();
 
         #[allow(clippy::unwrap_used)]
-        if chain_set.get(chain_id_trim).is_none() {
+        if chain_set.get(chain_id_trim).is_some() {
             for chain in &mut self.chains.iter_mut().rev() {
                 if chain.id() == chain_id_trim {
                     current_chain = chain;

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -414,8 +414,9 @@ impl<'a> Model {
         conformer_id: (&str, Option<&str>),
     ) {
         // let mut found = false;
+        let chain_id_trim = chain_id.trim();
         let mut new_chain =
-            Chain::new(chain_id.trim()).expect("Invalid characters in chain creation");
+            Chain::new(chain_id_trim).expect("Invalid characters in chain creation");
         let mut current_chain = &mut new_chain;
 
         #[allow(clippy::unwrap_used)]
@@ -423,18 +424,18 @@ impl<'a> Model {
             .chain_set
             .lock()
             .unwrap()
-            .get(chain_id.trim())
+            .get(chain_id_trim)
             .is_none()
         {
             for chain in &mut self.chains.iter_mut().rev() {
-                if chain.id() == chain_id.trim() {
+                if chain.id() == chain_id_trim {
                     current_chain = chain;
                     // found = true;
                     CHAIN_RES_IN_PDB
                         .chain_set
                         .lock()
                         .unwrap()
-                        .insert(chain_id.trim().to_owned());
+                        .insert(chain_id_trim.to_owned());
                     break;
                 }
             }

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -418,31 +418,31 @@ impl<'a> Model {
         let mut new_chain =
             Chain::new(chain_id_trim).expect("Invalid characters in chain creation");
         let mut current_chain = &mut new_chain;
+        #[allow(clippy::unwrap_used)]
+        let mut chain_set = CHAIN_RES_IN_PDB.chain_set.lock().unwrap();
 
         #[allow(clippy::unwrap_used)]
-        if CHAIN_RES_IN_PDB
-            .chain_set
-            .lock()
-            .unwrap()
-            .get(chain_id_trim)
-            .is_none()
-        {
+        if chain_set.get(chain_id_trim).is_none() {
             for chain in &mut self.chains.iter_mut().rev() {
                 if chain.id() == chain_id_trim {
                     current_chain = chain;
                     // found = true;
-                    CHAIN_RES_IN_PDB
-                        .chain_set
-                        .lock()
-                        .unwrap()
-                        .insert(chain_id_trim.to_owned());
                     break;
                 }
             }
         } else {
+            chain_set.insert(chain_id_trim.to_owned());
             self.chains.push(new_chain);
             current_chain = (&mut self.chains).last_mut().unwrap();
         }
+
+        // for chain in &mut self.chains.iter_mut().rev() {
+        //     if chain.id() == chain_id_trim {
+        //         current_chain = chain;
+        //         found = true;
+        //         break;
+        //     }
+        // }
 
         // #[allow(clippy::unwrap_used)]
         // if !found {

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -6,6 +6,7 @@ use crate::transformation::*;
 use doc_cfg::doc_cfg;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
+use std::sync::Mutex;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -51,6 +52,18 @@ pub struct PDB {
     models: Vec<Model>,
     /// Bonds in this PDB.
     bonds: Vec<(usize, usize, Bond)>,
+}
+
+pub(crate) struct ChainResSet {
+    pub(crate) chain_set: Mutex<HashSet<String>>,
+    pub(crate) residue_set: Mutex<HashSet<(isize, Option<String>)>>,
+}
+
+lazy_static! {
+    pub(crate) static ref CHAIN_RES_IN_PDB: ChainResSet = ChainResSet {
+        chain_set: Mutex::new(HashSet::new()),
+        residue_set: Mutex::new(HashSet::new())
+    };
 }
 
 /// # Creators
@@ -972,6 +985,7 @@ impl<'a> PDB {
     }
 }
 
+use std::collections::HashSet;
 use std::fmt;
 impl fmt::Display for PDB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -54,6 +54,7 @@ pub struct PDB {
     bonds: Vec<(usize, usize, Bond)>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ChainResSet {
     pub(crate) chain_set: Mutex<HashSet<String>>,
     pub(crate) residue_set: Mutex<HashSet<(isize, Option<String>)>>,

--- a/tests/read_write_pdbs.rs
+++ b/tests/read_write_pdbs.rs
@@ -61,7 +61,7 @@ fn do_something(file: &str, folder: &str, name: &str) {
         time.as_millis()
     );
 
-    assert!(!(pdb.total_atom_count() == 0), "No atoms found");
+    assert!(pdb.total_atom_count() != 0, "No atoms found");
 
     println!("PDB parsed");
 


### PR DESCRIPTION
Fixes #86
Fixes #81 
I tried a different approach than previously. The idea of checking for membership in a set to determine whether the Residue or Chain `Vec` should be traversed remains the same.
This time, however, I stored both sets in a global struct within a `lazy_static`. This is wrapped in a `Mutex` for thread-safe access and mutability. I chose this because storing this information in one of the existing structs would have led to problems with shared mutability and access, I think.
I profiled this with `large.pdb` and it drastically reduces the time taken by the `add_atom` methods.
Problems will arise whenever someone parses a PDB file, then removes full residues or chains and then adds atoms again.
Like you said, the information needs to be kept in sync to prevent this but I'm not sure how to do that yet without massive overhead.
