### PR TITLE
Added model removal helper functions

### DIFF
--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -713,9 +713,9 @@ impl<'a> PDB {
     /// * `idxs` - the indices of the Models to keep
     ///
     /// ## Returns
-    /// `None` if any of the indices are out of bounds or if no models were removed.
-    /// `Some(())` if any models were removed.
-    pub fn remove_models_except(&mut self, idxs: &[usize]) -> Option<()> {
+    /// `None` if any of the indices are out of bounds.
+    /// `Some(usize)` the number of models removed.
+    pub fn remove_models_except(&mut self, idxs: &[usize]) -> Option<usize> {
         let start_count = self.model_count();
         let mut removed = 0_usize;
 
@@ -733,11 +733,7 @@ impl<'a> PDB {
 
         self.models.truncate(start_count - removed);
 
-        if self.model_count() == start_count {
-            None // Nothing was removed
-        } else {
-            Some(()) // Something was removed
-        }
+        Some(removed)
     }
 
     /// Remove all Models except for the first one.
@@ -745,7 +741,7 @@ impl<'a> PDB {
     /// ## Panics
     /// Panics if there are no models.
     pub fn remove_all_models_except_first(&mut self) {
-        if self.model_count() == 1 {
+        if self.model_count() <= 1 {
             return;
         }
 
@@ -1067,8 +1063,13 @@ mod tests {
             assert_eq!(test_pdb.model_count(), model_count - 1);
 
             let mut test_pdb = pdb.clone();
-            test_pdb.remove_all_models_except_first(); // calls remove_models_except, so no need to test that explicitly
+            test_pdb.remove_all_models_except_first();
 
+            assert_eq!(test_pdb.model_count(), 1);
+            assert_eq!(test_pdb.model(0).unwrap(), pdb.model(0).unwrap());
+
+            let mut test_pdb = pdb.clone();
+            test_pdb.remove_models_except(&[0]);
             assert_eq!(test_pdb.model_count(), 1);
             assert_eq!(test_pdb.model(0).unwrap(), pdb.model(0).unwrap());
         }

--- a/tests/clipped.rs
+++ b/tests/clipped.rs
@@ -4,9 +4,17 @@ use std::io::{BufRead, BufReader};
 
 /// Open a test file containing more than 9999 residues and 99999 atoms, save it and check if the
 /// saved file was properly clipped.
+
 #[test]
 fn clipped() {
-    let (pdb, errors) = pdbtbx::open("example-pdbs/large.pdb", StrictnessLevel::Strict).unwrap();
+    let root = env!("CARGO_MANIFEST_DIR");
+    let path = format!("{}/{}", root, "example-pdbs/large.pdb");
+    let dump_dir = format!("{}/{}", root, "dump");
+
+    // make dumps directory
+    std::fs::create_dir_all(dump_dir).unwrap();
+
+    let (pdb, errors) = pdbtbx::open(path, StrictnessLevel::Strict).unwrap();
     let pdb_errors = save(&pdb, "dump/large.pdb", StrictnessLevel::Loose);
     print!("{:?}", errors);
     print!("{:?}", pdb_errors);

--- a/tests/insertion_codes.rs
+++ b/tests/insertion_codes.rs
@@ -8,8 +8,7 @@ fn insertion_codes() {
     // make dumps directory
     std::fs::create_dir_all(dump_dir).unwrap();
 
-    let (pdb, errors) =
-        pdbtbx::open(path, StrictnessLevel::Strict).unwrap();
+    let (pdb, errors) = pdbtbx::open(path, StrictnessLevel::Strict).unwrap();
     let pdb_errors = save(&pdb, "dump/insertion_codes.pdb", StrictnessLevel::Loose);
     let (pdb2, _) = pdbtbx::open("dump/insertion_codes.pdb", StrictnessLevel::Strict).unwrap();
     print!("{errors:?}");

--- a/tests/insertion_codes.rs
+++ b/tests/insertion_codes.rs
@@ -2,8 +2,14 @@ use pdbtbx::*;
 
 #[test]
 fn insertion_codes() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let path = format!("{}/{}", root, "example-pdbs/insertion_codes.pdb");
+    let dump_dir = format!("{}/{}", root, "dump");
+    // make dumps directory
+    std::fs::create_dir_all(dump_dir).unwrap();
+
     let (pdb, errors) =
-        pdbtbx::open("example-pdbs/insertion_codes.pdb", StrictnessLevel::Strict).unwrap();
+        pdbtbx::open(path, StrictnessLevel::Strict).unwrap();
     let pdb_errors = save(&pdb, "dump/insertion_codes.pdb", StrictnessLevel::Loose);
     let (pdb2, _) = pdbtbx::open("dump/insertion_codes.pdb", StrictnessLevel::Strict).unwrap();
     print!("{:?}", errors);


### PR DESCRIPTION
I have added some helper functions for removing models from a PDB. This is a common operation that I have been needing, so thought I would add it to the library.

I also fixed two of the tests which where failing due to issues with finding the PDB files, so they now use a path relative to the manifest to find the files, which should be more robust to files being moved around.