### PR TITLE
Fixed chain auto-capitalisation issue

### DIFF
--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -43,7 +43,7 @@ impl<'a> Chain {
         id: impl AsRef<str>,
         residues: impl Iterator<Item = Residue>,
     ) -> Option<Chain> {
-        prepare_identifier(id).map(|id| Chain {
+        prepare_identifier_case_sensitive(id).map(|id| Chain {
             id,
             residues: residues.collect(),
             database_reference: None,
@@ -58,7 +58,9 @@ impl<'a> Chain {
     /// Set the ID of the Chain, returns `false` if the new id is an invalid character.
     /// The ID will be changed to uppercase as requested by PDB/PDBx standard.
     pub fn set_id(&mut self, new_id: impl AsRef<str>) -> bool {
-        prepare_identifier(new_id).map(|id| self.id = id).is_some()
+        prepare_identifier_case_sensitive(new_id)
+            .map(|id| self.id = id)
+            .is_some()
     }
 
     /// Get the database reference, if any, for this chain.

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -28,7 +28,7 @@ impl<'a> Chain {
     /// It returns `None` if the identifier is an invalid character.
     #[must_use]
     pub fn new(id: impl AsRef<str>) -> Option<Chain> {
-        prepare_identifier(id).map(|id| Chain {
+        prepare_identifier_case_sensitive(id).map(|id| Chain {
             id,
             residues: Vec::new(),
             database_reference: None,

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -28,7 +28,7 @@ impl<'a> Chain {
     /// It returns `None` if the identifier is an invalid character.
     #[must_use]
     pub fn new(id: impl AsRef<str>) -> Option<Chain> {
-        prepare_identifier_case_sensitive(id).map(|id| Chain {
+        prepare_identifier(id).map(|id| Chain {
             id,
             residues: Vec::new(),
             database_reference: None,
@@ -43,7 +43,7 @@ impl<'a> Chain {
         id: impl AsRef<str>,
         residues: impl Iterator<Item = Residue>,
     ) -> Option<Chain> {
-        prepare_identifier_case_sensitive(id).map(|id| Chain {
+        prepare_identifier(id).map(|id| Chain {
             id,
             residues: residues.collect(),
             database_reference: None,
@@ -58,7 +58,7 @@ impl<'a> Chain {
     /// Set the ID of the Chain, returns `false` if the new id is an invalid character.
     /// The ID will be changed to uppercase as requested by PDB/PDBx standard.
     pub fn set_id(&mut self, new_id: impl AsRef<str>) -> bool {
-        prepare_identifier_case_sensitive(new_id)
+        prepare_identifier(new_id)
             .map(|id| self.id = id)
             .is_some()
     }

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -58,9 +58,7 @@ impl<'a> Chain {
     /// Set the ID of the Chain, returns `false` if the new id is an invalid character.
     /// The ID will be changed to uppercase as requested by PDB/PDBx standard.
     pub fn set_id(&mut self, new_id: impl AsRef<str>) -> bool {
-        prepare_identifier(new_id)
-            .map(|id| self.id = id)
-            .is_some()
+        prepare_identifier(new_id).map(|id| self.id = id).is_some()
     }
 
     /// Get the database reference, if any, for this chain.

--- a/src/structs/chain.rs
+++ b/src/structs/chain.rs
@@ -577,7 +577,7 @@ mod tests {
         assert!(!a.set_id("Oͦ"));
         assert_eq!(a.id(), "A");
         a.set_id("atom");
-        assert_eq!(a.id(), "ATOM");
+        assert_eq!(a.id(), "atom");
     }
 
     #[test]

--- a/src/structs/conformer.rs
+++ b/src/structs/conformer.rs
@@ -38,7 +38,7 @@ impl Conformer {
         alt_loc: Option<&str>,
         atom: Option<Atom>,
     ) -> Option<Conformer> {
-        prepare_identifier(name).map(|n| {
+        prepare_identifier_uppercase(name).map(|n| {
             let mut res = Conformer {
                 name: n,
                 alternative_location: None,
@@ -46,7 +46,7 @@ impl Conformer {
                 modification: None,
             };
             if let Some(al) = alt_loc {
-                res.alternative_location = prepare_identifier(al);
+                res.alternative_location = prepare_identifier_uppercase(al);
             }
             if let Some(a) = atom {
                 res.atoms.push(a);
@@ -65,7 +65,7 @@ impl Conformer {
     /// ## Fails
     /// It fails if any of the characters of the new name are invalid.
     pub fn set_name(&mut self, new_name: impl AsRef<str>) -> bool {
-        prepare_identifier(new_name)
+        prepare_identifier_uppercase(new_name)
             .map(|n| self.name = n)
             .is_some()
     }
@@ -80,7 +80,7 @@ impl Conformer {
     /// ## Fails
     /// It fails if any of the characters of the new alternative location are invalid.
     pub fn set_alternative_location(&mut self, new_loc: &str) -> bool {
-        if let Some(l) = prepare_identifier(new_loc) {
+        if let Some(l) = prepare_identifier_uppercase(new_loc) {
             self.alternative_location = Some(l);
             true
         } else {

--- a/src/structs/helper.rs
+++ b/src/structs/helper.rs
@@ -21,7 +21,14 @@ pub fn valid_identifier(text: impl AsRef<str>) -> bool {
 /// Also turns the identifier to uppercase.
 pub fn prepare_identifier(text: impl AsRef<str>) -> Option<String> {
     let text = text.as_ref();
-    (valid_identifier(text) && !text.trim().is_empty()).then(|| text.trim().to_ascii_uppercase())
+    prepare_identifier_case_sensitive(text).map(|s| s.to_uppercase())
+}
+
+/// Creates a valid identifier from the given string slice.
+/// Does not change the case.
+pub fn prepare_identifier_case_sensitive(text: impl AsRef<str>) -> Option<String> {
+    let text = text.as_ref();
+    (valid_identifier(text) && !text.trim().is_empty()).then(|| text.trim().to_string())
 }
 
 const ALPHABET: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/src/structs/helper.rs
+++ b/src/structs/helper.rs
@@ -19,14 +19,14 @@ pub fn valid_identifier(text: impl AsRef<str>) -> bool {
 
 /// Creates a valid identifier from the given string slice.
 /// Also turns the identifier to uppercase.
-pub fn prepare_identifier(text: impl AsRef<str>) -> Option<String> {
+pub fn prepare_identifier_uppercase(text: impl AsRef<str>) -> Option<String> {
     let text = text.as_ref();
-    prepare_identifier_case_sensitive(text).map(|s| s.to_uppercase())
+    prepare_identifier(text).map(|s| s.to_uppercase())
 }
 
 /// Creates a valid identifier from the given string slice.
 /// Does not change the case.
-pub fn prepare_identifier_case_sensitive(text: impl AsRef<str>) -> Option<String> {
+pub fn prepare_identifier(text: impl AsRef<str>) -> Option<String> {
     let text = text.as_ref();
     (valid_identifier(text) && !text.trim().is_empty()).then(|| text.trim().to_string())
 }

--- a/src/structs/residue.rs
+++ b/src/structs/residue.rs
@@ -73,7 +73,7 @@ impl<'a> Residue {
     /// Set the insertion code of the Residue.
     /// Fails and returns false if the `new_code` contains invalid characters
     pub fn set_insertion_code(&mut self, new_code: impl AsRef<str>) -> bool {
-        prepare_identifier(new_code)
+        prepare_identifier_uppercase(new_code)
             .map(|c| self.insertion_code = Some(c))
             .is_some()
     }
@@ -373,7 +373,7 @@ impl<'a> Residue {
     /// It panics if the Residue name contains any invalid characters.
     pub fn add_atom(&mut self, new_atom: Atom, conformer_id: (impl AsRef<str>, Option<&str>)) {
         let mut found = false;
-        let name = prepare_identifier(conformer_id.0).expect("Invalid Conformer ID");
+        let name = prepare_identifier_uppercase(conformer_id.0).expect("Invalid Conformer ID");
         let conformer_id = (name.as_str(), conformer_id.1);
         let mut new_conformer = Conformer::new(conformer_id.0, conformer_id.1, None)
             .expect("Invalid chars in Residue creation");


### PR DESCRIPTION
#109 

Problem: Some PDB files contain two occurrences of the same chain ID, e.g., B and b. The library automatically capitalizes change IDs, this leads to a chain ID conflict which is not possible to resolve simply.

Solution: Remove the functionality which automatically capitalizes the values.

Notes: 

- This may lead to breaking changes for users who assume automatic captialisation.
- Maybe this should be handled by a feature flag or an option being passed to the PDB open function, which allows for the selection of whether to use automatic capitalisation.