### PR TITLE
add `unique_residue_names`

### DIFF
--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1052,7 +1052,7 @@ impl<'a> PDB {
         chains
     }
 
-    /// Returns a vector of unique conformers present in the PDB file.
+    /// Returns a vector of unique conformer names present in the PDB file.
     ///
     /// # Arguments
     ///
@@ -1060,16 +1060,16 @@ impl<'a> PDB {
     ///
     /// # Returns
     ///
-    /// * `Vec<String>` - A vector of unique residue names.
+    /// * `Vec<String>` - A vector of unique conformer names.
     pub fn unique_conformer_names(&self) -> Vec<String> {
-        let mut resnames = Vec::new();
-        for conformers in self.conformers() {
-            let resname = conformers.name().to_owned();
-            if let Some(index) = resnames.binary_search(&resname).ok() {
-                resnames.insert(index, resname);
+        let mut names = Vec::new();
+        for conformer in self.conformers() {
+            let name = conformer.name().to_owned();
+            if let Some(index) = names.binary_search(&name).err() {
+                names.insert(index, name);
             }
         }
-        resnames
+        names
     }
 }
 
@@ -1434,5 +1434,7 @@ mod tests {
         ];
 
         assert!(reslist.iter().all(|x| expected_reslist.contains(x)));
+        assert!(expected_reslist.iter().all(|x| reslist.contains(x)));
+        assert_eq!(reslist.len(), 19);
     }
 }

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1052,7 +1052,7 @@ impl<'a> PDB {
         chains
     }
 
-    /// Returns a vector of unique residue names present in the PDB file.
+    /// Returns a vector of unique conformers present in the PDB file.
     ///
     /// # Arguments
     ///
@@ -1061,10 +1061,10 @@ impl<'a> PDB {
     /// # Returns
     ///
     /// * `Vec<String>` - A vector of unique residue names.
-    pub fn unique_residue_names(&self) -> Vec<String> {
+    pub fn unique_conformer_names(&self) -> Vec<String> {
         let mut resnames = Vec::new();
-        for residue in self.residues() {
-            let resname = residue.name().unwrap().to_owned();
+        for conformers in self.conformers() {
+            let resname = conformers.name().to_owned();
             if let Some(index) = resnames.binary_search(&resname).ok() {
                 resnames.insert(index, resname);
             }
@@ -1404,13 +1404,13 @@ mod tests {
         assert_eq!(chainmap, my_map);
     }
     #[test]
-    fn test_unique_residue_names() {
+    fn test_unique_conformer_names() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("example-pdbs")
             .join("1ubq.pdb");
         let (pdb, _) = crate::open(path.to_str().unwrap(), crate::StrictnessLevel::Loose).unwrap();
 
-        let reslist = pdb.unique_residue_names();
+        let reslist = pdb.unique_conformer_names();
         let expected_reslist: Vec<String> = vec![
             "MET".to_string(),
             "GLN".to_string(),

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1061,7 +1061,7 @@ impl<'a> PDB {
     /// # Returns
     ///
     /// * `Vec<String>` - A vector of unique residue names.
-    pub fn residues_list(&self) -> Vec<String> {
+    pub fn unique_residue_names(&self) -> Vec<String> {
         let mut resnames = Vec::new();
         for residue in self.residues() {
             let resname = residue.name().unwrap().to_owned();
@@ -1404,13 +1404,13 @@ mod tests {
         assert_eq!(chainmap, my_map);
     }
     #[test]
-    fn test_residues_list() {
+    fn test_unique_residue_names() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("example-pdbs")
             .join("1ubq.pdb");
         let (pdb, _) = crate::open(path.to_str().unwrap(), crate::StrictnessLevel::Loose).unwrap();
 
-        let reslist = pdb.residues_list();
+        let reslist = pdb.unique_residue_names();
         let expected_reslist: Vec<String> = vec![
             "MET".to_string(),
             "GLN".to_string(),

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1065,9 +1065,8 @@ impl<'a> PDB {
         let mut resnames = Vec::new();
         for residue in self.residues() {
             let resname = residue.name().unwrap().to_owned();
-            let index = resnames.binary_search(&resname);
-            if index.is_err() {
-                resnames.insert(index.unwrap_err(), resname);
+            if let Some(index) = resnames.binary_search(&resname).ok() {
+                resnames.insert(index, resname);
             }
         }
         resnames

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1051,6 +1051,26 @@ impl<'a> PDB {
         }
         chains
     }
+
+    /// Returns a vector of unique residue names present in the PDB file.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the PDB struct.
+    ///
+    /// # Returns
+    ///
+    /// * `Vec<String>` - A vector of unique residue names.
+    pub fn residues_list(&self) -> Vec<String> {
+        let mut resnames = Vec::new();
+        for residue in self.residues() {
+            let resname = residue.name().unwrap().to_owned();
+            if !resnames.contains(&resname) {
+                resnames.push(resname);
+            }
+        }
+        resnames
+    }
 }
 
 use std::collections::HashMap;
@@ -1382,5 +1402,37 @@ mod tests {
         .collect();
 
         assert_eq!(chainmap, my_map);
+    }
+    #[test]
+    fn test_residues_list() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("example-pdbs")
+            .join("1ubq.pdb");
+        let (pdb, _) = crate::open(path.to_str().unwrap(), crate::StrictnessLevel::Loose).unwrap();
+
+        let reslist = pdb.residues_list();
+        let expected_reslist: Vec<String> = vec![
+            "MET".to_string(),
+            "GLN".to_string(),
+            "ILE".to_string(),
+            "PHE".to_string(),
+            "VAL".to_string(),
+            "LYS".to_string(),
+            "THR".to_string(),
+            "LEU".to_string(),
+            "GLY".to_string(),
+            "GLU".to_string(),
+            "PRO".to_string(),
+            "SER".to_string(),
+            "ASP".to_string(),
+            "ASN".to_string(),
+            "ALA".to_string(),
+            "ARG".to_string(),
+            "TYR".to_string(),
+            "HIS".to_string(),
+            "HOH".to_string(),
+        ];
+
+        assert_eq!(reslist, expected_reslist);
     }
 }

--- a/src/structs/pdb.rs
+++ b/src/structs/pdb.rs
@@ -1065,8 +1065,9 @@ impl<'a> PDB {
         let mut resnames = Vec::new();
         for residue in self.residues() {
             let resname = residue.name().unwrap().to_owned();
-            if !resnames.contains(&resname) {
-                resnames.push(resname);
+            let index = resnames.binary_search(&resname);
+            if index.is_err() {
+                resnames.insert(index.unwrap_err(), resname);
             }
         }
         resnames
@@ -1433,6 +1434,6 @@ mod tests {
             "HOH".to_string(),
         ];
 
-        assert_eq!(reslist, expected_reslist);
+        assert!(reslist.iter().all(|x| expected_reslist.contains(x)));
     }
 }


### PR DESCRIPTION
This PR adds the `residues_list` utils, its a simple method that lists all the residue names in a given PDB.