### PR TITLE
Add a Nucleic Acid-Containing PDB to the test suite. 

### DIFF
--- a/example-pdbs/1BC8.pdb
+++ b/example-pdbs/1BC8.pdb
@@ -1,0 +1,1756 @@
+HEADER    TRANSCRIPTION/DNA                       05-MAY-98   1BC8              
+TITLE     STRUCTURES OF SAP-1 BOUND TO DNA SEQUENCES FROM THE E74 AND           
+TITLE    2 C-FOS PROMOTERS PROVIDE INSIGHTS INTO HOW ETS PROTEINS               
+TITLE    3 DISCRIMINATE BETWEEN RELATED DNA TARGETS                             
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: DNA (5'-D(*TP*AP*CP*CP*GP*GP*AP*AP*GP*T)-3');              
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 SYNONYM: E74 DNA FRAGMENT;                                           
+COMPND   5 ENGINEERED: YES;                                                     
+COMPND   6 MOL_ID: 2;                                                           
+COMPND   7 MOLECULE: DNA (5'-D(*AP*AP*CP*TP*TP*CP*CP*GP*GP*T)-3');              
+COMPND   8 CHAIN: B;                                                            
+COMPND   9 SYNONYM: E74 DNA FRAGMENT;                                           
+COMPND  10 ENGINEERED: YES;                                                     
+COMPND  11 MOL_ID: 3;                                                           
+COMPND  12 MOLECULE: PROTEIN (SAP-1 ETS DOMAIN);                                
+COMPND  13 CHAIN: C;                                                            
+COMPND  14 FRAGMENT: ETS DOMAIN, RESIDUES 1-93;                                 
+COMPND  15 SYNONYM: SAP-1;                                                      
+COMPND  16 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 SYNTHETIC: YES;                                                      
+SOURCE   3 MOL_ID: 2;                                                           
+SOURCE   4 SYNTHETIC: YES;                                                      
+SOURCE   5 MOL_ID: 3;                                                           
+SOURCE   6 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   7 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   8 ORGANISM_TAXID: 9606;                                                
+SOURCE   9 CELLULAR_LOCATION: NUCLEUS;                                          
+SOURCE  10 GENE: SAP-1 RESIDUES 1-93;                                           
+SOURCE  11 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE  12 EXPRESSION_SYSTEM_TAXID: 562;                                        
+SOURCE  13 EXPRESSION_SYSTEM_STRAIN: BL21(DE3);                                 
+SOURCE  14 EXPRESSION_SYSTEM_VARIANT: LYSS;                                     
+SOURCE  15 EXPRESSION_SYSTEM_VECTOR_TYPE: BACTERIA;                             
+SOURCE  16 EXPRESSION_SYSTEM_VECTOR: PRSETA                                     
+KEYWDS    ETS DOMAIN, DNA-BINDING DOMAIN, WINGED HELIX-TURN-HELIX,              
+KEYWDS   2 CRYSTAL STRUCTURE, DNA-BINDING SPECIFICITY,                          
+KEYWDS   3 TRANSCRIPTION/DNA COMPLEX                                            
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    Y.MO,B.VAESSEN,K.JOHNSTON,R.MARMORSTEIN                               
+REVDAT   3   24-FEB-09 1BC8    1       VERSN                                    
+REVDAT   2   01-APR-03 1BC8    1       JRNL                                     
+REVDAT   1   01-DEC-98 1BC8    0                                                
+JRNL        AUTH   Y.MO,B.VAESSEN,K.JOHNSTON,R.MARMORSTEIN                      
+JRNL        TITL   STRUCTURES OF SAP-1 BOUND TO DNA TARGETS FROM THE            
+JRNL        TITL 2 E74 AND C-FOS PROMOTERS: INSIGHTS INTO DNA                   
+JRNL        TITL 3 SEQUENCE DISCRIMINATION BY ETS PROTEINS.                     
+JRNL        REF    MOL.CELL                      V.   2   201 1998              
+JRNL        REFN                   ISSN 1097-2765                               
+JRNL        PMID   9734357                                                      
+JRNL        DOI    10.1016/S1097-2765(00)80130-6                                
+REMARK   1                                                                      
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.93 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : X-PLOR 3.851                                         
+REMARK   3   AUTHORS     : BRUNGER                                              
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.93                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 28.90                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 2.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : 1000000.000                    
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : 0.0010                         
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 96.4                           
+REMARK   3   NUMBER OF REFLECTIONS             : 10700                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE            (WORKING SET) : 0.220                           
+REMARK   3   FREE R VALUE                     : 0.277                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 10.100                          
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : NULL                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 8                            
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.02                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 1.93                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 91.20                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 1129                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.3144                       
+REMARK   3   BIN FREE R VALUE                    : 0.3956                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 8.50                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : NULL                         
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : NULL                         
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 790                                     
+REMARK   3   NUCLEIC ACID ATOMS       : 404                                     
+REMARK   3   HETEROGEN ATOMS          : 2                                       
+REMARK   3   SOLVENT ATOMS            : 160                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 14.80                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 17.00                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.25                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.26                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.32                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.29                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.007                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.19                            
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : 23.00                           
+REMARK   3   IMPROPER ANGLES        (DEGREES) : 1.14                            
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : RESTRAINED                                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : PROTEIN_REP.PARAM                              
+REMARK   3  PARAMETER FILE  2  : DNA-RNA.PARAM                                  
+REMARK   3  PARAMETER FILE  3  : NULL                                           
+REMARK   3  PARAMETER FILE  4  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : TOPHCSDX.PRO                                   
+REMARK   3  TOPOLOGY FILE  2   : DNA-RNA.TOP                                    
+REMARK   3  TOPOLOGY FILE  3   : TOPH11.WAT                                     
+REMARK   3  TOPOLOGY FILE  4   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1BC8 COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 15-DEC-97                          
+REMARK 200  TEMPERATURE           (KELVIN) : 110                                
+REMARK 200  PH                             : 6.0                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : N                                  
+REMARK 200  RADIATION SOURCE               : ROTATING ANODE                     
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : RIGAKU RU200                       
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.5418                             
+REMARK 200  MONOCHROMATOR                  : NI FILTER                          
+REMARK 200  OPTICS                         : MIRRORS                            
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : IMAGE PLATE                        
+REMARK 200  DETECTOR MANUFACTURER          : MARRESEARCH                        
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO                              
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 10728                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 1.930                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 28.900                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 96.7                               
+REMARK 200  DATA REDUNDANCY                : 7.100                              
+REMARK 200  R MERGE                    (I) : 0.07100                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 15.0000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 1.93                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.02                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 91.7                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.14100                            
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MULTIPLE ISOMORPHOUS         
+REMARK 200  REPLACEMENT                                                         
+REMARK 200 SOFTWARE USED: PHASES                                                
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 42.20                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.13                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 50 MM NA CACODYLATE (PH 6.0), 5.0%       
+REMARK 280  PEG8000, 20 MM ZINC ACETATE                                         
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 1 21 1                         
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y+1/2,-Z                                             
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000       27.83500            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: TRIMERIC                          
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C                               
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   ND2  ASN C    92     O    HOH C   113              2.10            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASN C  92       74.69   -118.92                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: PLANAR GROUPS                                              
+REMARK 500                                                                      
+REMARK 500 PLANAR GROUPS IN THE FOLLOWING RESIDUES HAVE A TOTAL                 
+REMARK 500 RMS DISTANCE OF ALL ATOMS FROM THE BEST-FIT PLANE                    
+REMARK 500 BY MORE THAN AN EXPECTED VALUE OF 6*RMSD, WITH AN                    
+REMARK 500 RMSD 0.02 ANGSTROMS, OR AT LEAST ONE ATOM HAS                        
+REMARK 500 AN RMSD GREATER THAN THIS VALUE                                      
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        RMS     TYPE                                    
+REMARK 500     DG B  19         0.07    SIDE_CHAIN                              
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 525                                                                      
+REMARK 525 SOLVENT                                                              
+REMARK 525                                                                      
+REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
+REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
+REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
+REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
+REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
+REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
+REMARK 525 NUMBER; I=INSERTION CODE):                                           
+REMARK 525                                                                      
+REMARK 525  M RES CSSEQI                                                        
+REMARK 525    HOH B 159        DISTANCE =  6.81 ANGSTROMS                       
+REMARK 525    HOH C 176        DISTANCE =  7.69 ANGSTROMS                       
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
+REMARK 620  SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                            
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN C  94  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 GLU C  89   OE2                                                    
+REMARK 620 2 HOH C 118   O   102.9                                              
+REMARK 620 N                    1                                               
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN B   2  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1  DG B  18   N7                                                     
+REMARK 620 2 HOH B  54   O   172.6                                              
+REMARK 620 3 HOH B 135   O    92.4  90.6                                        
+REMARK 620 4 HOH B 136   O   100.5  86.5  86.0                                  
+REMARK 620 5 HOH B 137   O    90.6  85.4 170.8 101.9                            
+REMARK 620 6 HOH B  82   O    98.7  74.3  94.5 160.8  76.4                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN C 94                   
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN B 2                    
+DBREF  1BC8 C    1    93  UNP    P28324   ELK4_HUMAN       1     93             
+DBREF  1BC8 A    1    10  PDB    1BC8     1BC8             1     10             
+DBREF  1BC8 B   11    20  PDB    1BC8     1BC8            11     20             
+SEQRES   1 A   10   DT  DA  DC  DC  DG  DG  DA  DA  DG  DT                      
+SEQRES   1 B   10   DA  DA  DC  DT  DT  DC  DC  DG  DG  DT                      
+SEQRES   1 C   93  MET ASP SER ALA ILE THR LEU TRP GLN PHE LEU LEU GLN          
+SEQRES   2 C   93  LEU LEU GLN LYS PRO GLN ASN LYS HIS MET ILE CYS TRP          
+SEQRES   3 C   93  THR SER ASN ASP GLY GLN PHE LYS LEU LEU GLN ALA GLU          
+SEQRES   4 C   93  GLU VAL ALA ARG LEU TRP GLY ILE ARG LYS ASN LYS PRO          
+SEQRES   5 C   93  ASN MET ASN TYR ASP LYS LEU SER ARG ALA LEU ARG TYR          
+SEQRES   6 C   93  TYR TYR VAL LYS ASN ILE ILE LYS LYS VAL ASN GLY GLN          
+SEQRES   7 C   93  LYS PHE VAL TYR LYS PHE VAL SER TYR PRO GLU ILE LEU          
+SEQRES   8 C   93  ASN MET                                                      
+HET     ZN  C  94       1                                                       
+HET     ZN  B   2       1                                                       
+HETNAM      ZN ZINC ION                                                         
+FORMUL   4   ZN    2(ZN 2+)                                                     
+FORMUL   6  HOH   *160(H2 O)                                                    
+HELIX    1  H1 THR C    6  LEU C   15  1                                  10    
+HELIX    2  H2 GLN C   37  ASN C   50  1                                  14    
+HELIX    3  H3 ASN C   55  ASN C   70  1                                  16    
+HELIX    4 3-1 GLN C   16  LYS C   21  5                                   6    
+HELIX    5 3-2 PRO C   88  ASN C   92  5                                   5    
+SHEET    1  S1 4 CYS C  25  TRP C  26  0                                        
+SHEET    2  S1 4 GLN C  32  LYS C  34 -1                                        
+SHEET    3  S1 4 VAL C  81  PHE C  84 -1                                        
+SHEET    4  S1 4 ILE C  72  LYS C  74 -1                                        
+LINK        ZN    ZN C  94                 OE2 GLU C  89     1555   1555  2.02  
+LINK        ZN    ZN C  94                 O   HOH C 118     1555   1555  1.95  
+LINK        ZN    ZN B   2                 N7   DG B  18     1555   1555  2.17  
+LINK        ZN    ZN B   2                 O   HOH B  54     1555   1555  2.12  
+LINK        ZN    ZN B   2                 O   HOH B 135     1555   1555  2.21  
+LINK        ZN    ZN B   2                 O   HOH B 136     1555   1555  2.35  
+LINK        ZN    ZN B   2                 O   HOH B 137     1555   1555  2.39  
+LINK        ZN    ZN B   2                 O   HOH B  82     1555   1555  2.57  
+CISPEP   1 TYR C   87    PRO C   88          0         0.12                     
+SITE     1 AC1  2 GLU C  89  HOH C 118                                          
+SITE     1 AC2  6  DG B  18  HOH B  54  HOH B  82  HOH B 135                    
+SITE     2 AC2  6 HOH B 136  HOH B 137                                          
+CRYST1   31.590   55.670   44.230  90.00 107.16  90.00 P 1 21 1      2          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.031656  0.000000  0.009775        0.00000                         
+SCALE2      0.000000  0.017963  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.023662        0.00000                         
+ATOM      1  O5'  DT A   1      18.304  10.313  14.820  1.00 17.18           O  
+ATOM      2  C5'  DT A   1      19.094   9.803  13.737  1.00 12.46           C  
+ATOM      3  C4'  DT A   1      18.917   8.315  13.559  1.00 18.60           C  
+ATOM      4  O4'  DT A   1      19.697   7.616  14.562  1.00 20.04           O  
+ATOM      5  C3'  DT A   1      17.470   7.855  13.741  1.00 16.09           C  
+ATOM      6  O3'  DT A   1      17.095   6.863  12.788  1.00 15.10           O  
+ATOM      7  C2'  DT A   1      17.458   7.238  15.125  1.00 14.72           C  
+ATOM      8  C1'  DT A   1      18.865   6.691  15.255  1.00 15.05           C  
+ATOM      9  N1   DT A   1      19.304   6.626  16.668  1.00 14.53           N  
+ATOM     10  C2   DT A   1      19.705   5.412  17.182  1.00 18.55           C  
+ATOM     11  O2   DT A   1      19.791   4.385  16.537  1.00 13.78           O  
+ATOM     12  N3   DT A   1      20.012   5.437  18.502  1.00 16.23           N  
+ATOM     13  C4   DT A   1      19.951   6.509  19.368  1.00 18.17           C  
+ATOM     14  O4   DT A   1      20.205   6.342  20.562  1.00 18.13           O  
+ATOM     15  C5   DT A   1      19.567   7.762  18.762  1.00 16.52           C  
+ATOM     16  C7   DT A   1      19.513   8.999  19.602  1.00 16.20           C  
+ATOM     17  C6   DT A   1      19.273   7.759  17.458  1.00 17.00           C  
+ATOM     18  P    DA A   2      15.599   6.249  12.825  1.00 16.79           P  
+ATOM     19  OP1  DA A   2      15.051   6.238  11.437  1.00 17.73           O  
+ATOM     20  OP2  DA A   2      14.829   6.923  13.914  1.00 17.63           O  
+ATOM     21  O5'  DA A   2      15.831   4.747  13.296  1.00 19.10           O  
+ATOM     22  C5'  DA A   2      16.645   3.854  12.539  1.00 17.15           C  
+ATOM     23  C4'  DA A   2      16.501   2.449  13.077  1.00 13.00           C  
+ATOM     24  O4'  DA A   2      17.058   2.395  14.415  1.00 17.27           O  
+ATOM     25  C3'  DA A   2      15.052   1.969  13.198  1.00 16.19           C  
+ATOM     26  O3'  DA A   2      14.977   0.578  12.848  1.00 13.90           O  
+ATOM     27  C2'  DA A   2      14.719   2.214  14.663  1.00 13.74           C  
+ATOM     28  C1'  DA A   2      16.062   2.014  15.360  1.00 14.39           C  
+ATOM     29  N9   DA A   2      16.254   2.824  16.570  1.00 14.09           N  
+ATOM     30  C8   DA A   2      16.103   4.182  16.715  1.00 16.98           C  
+ATOM     31  N7   DA A   2      16.322   4.612  17.935  1.00 18.93           N  
+ATOM     32  C5   DA A   2      16.643   3.462  18.643  1.00 15.08           C  
+ATOM     33  C6   DA A   2      16.964   3.235  20.000  1.00 18.66           C  
+ATOM     34  N6   DA A   2      17.022   4.194  20.924  1.00 14.45           N  
+ATOM     35  N1   DA A   2      17.226   1.969  20.377  1.00 20.40           N  
+ATOM     36  C2   DA A   2      17.176   1.003  19.457  1.00 16.64           C  
+ATOM     37  N3   DA A   2      16.887   1.084  18.163  1.00 13.95           N  
+ATOM     38  C4   DA A   2      16.619   2.355  17.813  1.00 15.74           C  
+ATOM     39  P    DC A   3      13.558  -0.169  12.821  1.00 14.83           P  
+ATOM     40  OP1  DC A   3      13.640  -1.321  11.905  1.00 19.09           O  
+ATOM     41  OP2  DC A   3      12.525   0.871  12.617  1.00 15.53           O  
+ATOM     42  O5'  DC A   3      13.380  -0.737  14.299  1.00 14.21           O  
+ATOM     43  C5'  DC A   3      14.400  -1.524  14.907  1.00 16.00           C  
+ATOM     44  C4'  DC A   3      13.967  -2.001  16.275  1.00 15.51           C  
+ATOM     45  O4'  DC A   3      14.336  -1.015  17.272  1.00 18.24           O  
+ATOM     46  C3'  DC A   3      12.472  -2.279  16.468  1.00 17.28           C  
+ATOM     47  O3'  DC A   3      12.313  -3.566  17.075  1.00 15.26           O  
+ATOM     48  C2'  DC A   3      12.009  -1.161  17.390  1.00 17.05           C  
+ATOM     49  C1'  DC A   3      13.266  -0.839  18.181  1.00 13.47           C  
+ATOM     50  N1   DC A   3      13.361   0.526  18.749  1.00 14.95           N  
+ATOM     51  C2   DC A   3      13.811   0.679  20.081  1.00 14.31           C  
+ATOM     52  O2   DC A   3      14.117  -0.328  20.740  1.00 13.83           O  
+ATOM     53  N3   DC A   3      13.895   1.920  20.611  1.00 17.87           N  
+ATOM     54  C4   DC A   3      13.551   2.986  19.881  1.00 15.67           C  
+ATOM     55  N4   DC A   3      13.648   4.189  20.454  1.00 17.05           N  
+ATOM     56  C5   DC A   3      13.090   2.863  18.530  1.00 17.58           C  
+ATOM     57  C6   DC A   3      13.015   1.628  18.010  1.00 15.35           C  
+ATOM     58  P    DC A   4      10.841  -4.169  17.337  1.00 13.52           P  
+ATOM     59  OP1  DC A   4      10.889  -5.642  17.128  1.00 11.14           O  
+ATOM     60  OP2  DC A   4       9.841  -3.354  16.599  1.00 14.42           O  
+ATOM     61  O5'  DC A   4      10.610  -3.896  18.887  1.00 18.88           O  
+ATOM     62  C5'  DC A   4      11.624  -4.211  19.840  1.00 17.04           C  
+ATOM     63  C4'  DC A   4      11.077  -4.102  21.242  1.00 13.77           C  
+ATOM     64  O4'  DC A   4      11.519  -2.836  21.796  1.00 16.13           O  
+ATOM     65  C3'  DC A   4       9.548  -4.087  21.270  1.00 14.89           C  
+ATOM     66  O3'  DC A   4       8.983  -5.058  22.133  1.00 21.15           O  
+ATOM     67  C2'  DC A   4       9.174  -2.695  21.730  1.00 14.30           C  
+ATOM     68  C1'  DC A   4      10.429  -2.136  22.378  1.00 15.84           C  
+ATOM     69  N1   DC A   4      10.556  -0.702  22.049  1.00 17.22           N  
+ATOM     70  C2   DC A   4      10.557   0.249  23.091  1.00 16.52           C  
+ATOM     71  O2   DC A   4      10.547  -0.140  24.273  1.00 17.28           O  
+ATOM     72  N3   DC A   4      10.560   1.564  22.778  1.00 15.50           N  
+ATOM     73  C4   DC A   4      10.559   1.949  21.496  1.00 13.37           C  
+ATOM     74  N4   DC A   4      10.505   3.253  21.236  1.00 17.30           N  
+ATOM     75  C5   DC A   4      10.602   1.011  20.425  1.00 13.99           C  
+ATOM     76  C6   DC A   4      10.612  -0.291  20.743  1.00 16.58           C  
+ATOM     77  P    DG A   5       7.455  -5.511  21.910  1.00 16.98           P  
+ATOM     78  OP1  DG A   5       7.431  -6.984  21.812  1.00 14.91           O  
+ATOM     79  OP2  DG A   5       6.832  -4.697  20.834  1.00 16.97           O  
+ATOM     80  O5'  DG A   5       6.759  -5.086  23.279  1.00 15.22           O  
+ATOM     81  C5'  DG A   5       7.337  -5.436  24.539  1.00 16.43           C  
+ATOM     82  C4'  DG A   5       6.876  -4.472  25.610  1.00 19.88           C  
+ATOM     83  O4'  DG A   5       7.321  -3.132  25.288  1.00 15.74           O  
+ATOM     84  C3'  DG A   5       5.362  -4.373  25.791  1.00 19.76           C  
+ATOM     85  O3'  DG A   5       5.084  -4.149  27.177  1.00 16.42           O  
+ATOM     86  C2'  DG A   5       4.998  -3.139  24.982  1.00 15.59           C  
+ATOM     87  C1'  DG A   5       6.203  -2.256  25.230  1.00 16.34           C  
+ATOM     88  N9   DG A   5       6.465  -1.239  24.213  1.00 14.70           N  
+ATOM     89  C8   DG A   5       6.402  -1.381  22.845  1.00 15.36           C  
+ATOM     90  N7   DG A   5       6.676  -0.276  22.204  1.00 15.80           N  
+ATOM     91  C5   DG A   5       6.938   0.650  23.208  1.00 16.23           C  
+ATOM     92  C6   DG A   5       7.280   2.026  23.126  1.00 15.00           C  
+ATOM     93  O6   DG A   5       7.421   2.721  22.118  1.00 19.50           O  
+ATOM     94  N1   DG A   5       7.454   2.589  24.393  1.00 17.96           N  
+ATOM     95  C2   DG A   5       7.313   1.908  25.583  1.00 19.25           C  
+ATOM     96  N2   DG A   5       7.525   2.605  26.721  1.00 16.42           N  
+ATOM     97  N3   DG A   5       6.988   0.633  25.665  1.00 15.96           N  
+ATOM     98  C4   DG A   5       6.816   0.069  24.451  1.00 14.08           C  
+ATOM     99  P    DG A   6       3.574  -4.238  27.728  1.00 15.18           P  
+ATOM    100  OP1  DG A   6       3.439  -5.516  28.484  1.00 15.91           O  
+ATOM    101  OP2  DG A   6       2.597  -3.914  26.651  1.00 17.41           O  
+ATOM    102  O5'  DG A   6       3.529  -3.055  28.788  1.00 14.00           O  
+ATOM    103  C5'  DG A   6       4.595  -2.864  29.713  1.00 17.89           C  
+ATOM    104  C4'  DG A   6       4.483  -1.505  30.357  1.00 14.78           C  
+ATOM    105  O4'  DG A   6       4.861  -0.450  29.443  1.00 16.57           O  
+ATOM    106  C3'  DG A   6       3.078  -1.162  30.839  1.00 17.24           C  
+ATOM    107  O3'  DG A   6       3.181  -0.493  32.087  1.00 16.38           O  
+ATOM    108  C2'  DG A   6       2.543  -0.236  29.760  1.00 15.42           C  
+ATOM    109  C1'  DG A   6       3.794   0.483  29.279  1.00 16.24           C  
+ATOM    110  N9   DG A   6       3.768   0.876  27.870  1.00 13.81           N  
+ATOM    111  C8   DG A   6       3.526   0.057  26.790  1.00 14.47           C  
+ATOM    112  N7   DG A   6       3.640   0.671  25.646  1.00 20.23           N  
+ATOM    113  C5   DG A   6       3.957   1.979  25.985  1.00 12.59           C  
+ATOM    114  C6   DG A   6       4.211   3.105  25.157  1.00 15.44           C  
+ATOM    115  O6   DG A   6       4.217   3.166  23.918  1.00 14.65           O  
+ATOM    116  N1   DG A   6       4.481   4.244  25.909  1.00 15.46           N  
+ATOM    117  C2   DG A   6       4.495   4.294  27.286  1.00 17.09           C  
+ATOM    118  N2   DG A   6       4.734   5.494  27.835  1.00 18.97           N  
+ATOM    119  N3   DG A   6       4.280   3.244  28.067  1.00 15.05           N  
+ATOM    120  C4   DG A   6       4.019   2.130  27.355  1.00 17.38           C  
+ATOM    121  P    DA A   7       1.858  -0.155  32.916  1.00 16.48           P  
+ATOM    122  OP1  DA A   7       2.280  -0.017  34.333  1.00 17.89           O  
+ATOM    123  OP2  DA A   7       0.793  -1.130  32.549  1.00 14.37           O  
+ATOM    124  O5'  DA A   7       1.457   1.274  32.352  1.00 16.83           O  
+ATOM    125  C5'  DA A   7       2.256   2.408  32.638  1.00 16.03           C  
+ATOM    126  C4'  DA A   7       1.571   3.659  32.146  1.00 17.62           C  
+ATOM    127  O4'  DA A   7       1.761   3.835  30.718  1.00 18.57           O  
+ATOM    128  C3'  DA A   7       0.062   3.741  32.403  1.00 17.77           C  
+ATOM    129  O3'  DA A   7      -0.223   5.027  32.953  1.00 18.36           O  
+ATOM    130  C2'  DA A   7      -0.543   3.574  31.013  1.00 13.69           C  
+ATOM    131  C1'  DA A   7       0.526   4.180  30.110  1.00 17.20           C  
+ATOM    132  N9   DA A   7       0.561   3.700  28.723  1.00 17.33           N  
+ATOM    133  C8   DA A   7       0.339   2.431  28.248  1.00 16.28           C  
+ATOM    134  N7   DA A   7       0.472   2.322  26.946  1.00 15.88           N  
+ATOM    135  C5   DA A   7       0.796   3.608  26.534  1.00 16.34           C  
+ATOM    136  C6   DA A   7       1.071   4.161  25.263  1.00 19.38           C  
+ATOM    137  N6   DA A   7       1.055   3.462  24.126  1.00 14.51           N  
+ATOM    138  N1   DA A   7       1.367   5.481  25.204  1.00 16.03           N  
+ATOM    139  C2   DA A   7       1.386   6.182  26.342  1.00 17.05           C  
+ATOM    140  N3   DA A   7       1.145   5.776  27.587  1.00 15.82           N  
+ATOM    141  C4   DA A   7       0.852   4.467  27.616  1.00 14.88           C  
+ATOM    142  P    DA A   8      -1.702   5.389  33.460  1.00 18.53           P  
+ATOM    143  OP1  DA A   8      -1.561   6.127  34.742  1.00 16.72           O  
+ATOM    144  OP2  DA A   8      -2.599   4.209  33.379  1.00 15.44           O  
+ATOM    145  O5'  DA A   8      -2.185   6.443  32.385  1.00 17.38           O  
+ATOM    146  C5'  DA A   8      -1.409   7.602  32.152  1.00 16.43           C  
+ATOM    147  C4'  DA A   8      -1.868   8.288  30.891  1.00 11.57           C  
+ATOM    148  O4'  DA A   8      -1.571   7.465  29.737  1.00 15.57           O  
+ATOM    149  C3'  DA A   8      -3.366   8.586  30.831  1.00 16.80           C  
+ATOM    150  O3'  DA A   8      -3.512   9.915  30.341  1.00 14.29           O  
+ATOM    151  C2'  DA A   8      -3.890   7.566  29.830  1.00 17.01           C  
+ATOM    152  C1'  DA A   8      -2.708   7.462  28.894  1.00 19.16           C  
+ATOM    153  N9   DA A   8      -2.646   6.287  28.027  1.00 15.34           N  
+ATOM    154  C8   DA A   8      -2.861   4.961  28.316  1.00 16.04           C  
+ATOM    155  N7   DA A   8      -2.739   4.168  27.273  1.00 16.72           N  
+ATOM    156  C5   DA A   8      -2.417   5.031  26.231  1.00 14.75           C  
+ATOM    157  C6   DA A   8      -2.153   4.819  24.852  1.00 16.65           C  
+ATOM    158  N6   DA A   8      -2.167   3.618  24.263  1.00 15.60           N  
+ATOM    159  N1   DA A   8      -1.865   5.902  24.097  1.00 19.88           N  
+ATOM    160  C2   DA A   8      -1.838   7.105  24.684  1.00 19.47           C  
+ATOM    161  N3   DA A   8      -2.065   7.431  25.958  1.00 15.72           N  
+ATOM    162  C4   DA A   8      -2.352   6.337  26.685  1.00 15.50           C  
+ATOM    163  P    DG A   9      -4.956  10.607  30.276  1.00 14.96           P  
+ATOM    164  OP1  DG A   9      -4.885  11.863  31.061  1.00 15.46           O  
+ATOM    165  OP2  DG A   9      -6.006   9.603  30.576  1.00 13.77           O  
+ATOM    166  O5'  DG A   9      -5.074  10.984  28.734  1.00 13.48           O  
+ATOM    167  C5'  DG A   9      -4.136  11.869  28.135  1.00 16.11           C  
+ATOM    168  C4'  DG A   9      -4.463  12.060  26.674  1.00 18.04           C  
+ATOM    169  O4'  DG A   9      -4.156  10.846  25.948  1.00 14.73           O  
+ATOM    170  C3'  DG A   9      -5.927  12.387  26.371  1.00 16.72           C  
+ATOM    171  O3'  DG A   9      -5.991  13.394  25.360  1.00 19.93           O  
+ATOM    172  C2'  DG A   9      -6.494  11.069  25.879  1.00 14.67           C  
+ATOM    173  C1'  DG A   9      -5.294  10.411  25.218  1.00 20.49           C  
+ATOM    174  N9   DG A   9      -5.318   8.951  25.254  1.00 14.69           N  
+ATOM    175  C8   DG A   9      -5.424   8.148  26.366  1.00 17.56           C  
+ATOM    176  N7   DG A   9      -5.433   6.876  26.080  1.00 15.14           N  
+ATOM    177  C5   DG A   9      -5.321   6.831  24.700  1.00 20.89           C  
+ATOM    178  C6   DG A   9      -5.280   5.728  23.832  1.00 16.26           C  
+ATOM    179  O6   DG A   9      -5.335   4.529  24.121  1.00 16.06           O  
+ATOM    180  N1   DG A   9      -5.165   6.122  22.498  1.00 17.21           N  
+ATOM    181  C2   DG A   9      -5.094   7.428  22.065  1.00 21.36           C  
+ATOM    182  N2   DG A   9      -4.988   7.619  20.737  1.00 14.52           N  
+ATOM    183  N3   DG A   9      -5.127   8.474  22.875  1.00 12.99           N  
+ATOM    184  C4   DG A   9      -5.244   8.103  24.171  1.00 17.78           C  
+ATOM    185  P    DT A  10      -7.414  13.887  24.796  1.00 16.26           P  
+ATOM    186  OP1  DT A  10      -7.222  15.289  24.332  1.00 15.56           O  
+ATOM    187  OP2  DT A  10      -8.502  13.575  25.763  1.00 13.41           O  
+ATOM    188  O5'  DT A  10      -7.631  12.962  23.511  1.00 13.59           O  
+ATOM    189  C5'  DT A  10      -6.781  13.101  22.371  1.00 15.79           C  
+ATOM    190  C4'  DT A  10      -7.422  12.481  21.152  1.00 16.32           C  
+ATOM    191  O4'  DT A  10      -7.287  11.044  21.195  1.00 16.97           O  
+ATOM    192  C3'  DT A  10      -8.913  12.766  20.979  1.00 18.99           C  
+ATOM    193  O3'  DT A  10      -9.196  12.942  19.592  1.00 15.40           O  
+ATOM    194  C2'  DT A  10      -9.566  11.479  21.453  1.00 16.43           C  
+ATOM    195  C1'  DT A  10      -8.549  10.431  21.020  1.00 17.74           C  
+ATOM    196  N1   DT A  10      -8.545   9.162  21.790  1.00 15.83           N  
+ATOM    197  C2   DT A  10      -8.395   7.963  21.106  1.00 12.93           C  
+ATOM    198  O2   DT A  10      -8.268   7.885  19.896  1.00 17.43           O  
+ATOM    199  N3   DT A  10      -8.402   6.847  21.907  1.00 17.21           N  
+ATOM    200  C4   DT A  10      -8.544   6.798  23.283  1.00 13.38           C  
+ATOM    201  O4   DT A  10      -8.535   5.711  23.865  1.00 14.60           O  
+ATOM    202  C5   DT A  10      -8.698   8.081  23.932  1.00 14.93           C  
+ATOM    203  C7   DT A  10      -8.860   8.129  25.419  1.00 22.05           C  
+ATOM    204  C6   DT A  10      -8.689   9.183  23.166  1.00 18.59           C  
+TER     205       DT A  10                                                      
+ATOM    206  O5'  DA B  11     -11.321  -3.165  21.625  1.00 17.00           O  
+ATOM    207  C5'  DA B  11     -12.292  -3.560  20.649  1.00 17.12           C  
+ATOM    208  C4'  DA B  11     -12.040  -2.969  19.280  1.00 17.24           C  
+ATOM    209  O4'  DA B  11     -12.252  -1.543  19.299  1.00 15.39           O  
+ATOM    210  C3'  DA B  11     -10.634  -3.172  18.721  1.00 15.49           C  
+ATOM    211  O3'  DA B  11     -10.731  -3.375  17.306  1.00 12.48           O  
+ATOM    212  C2'  DA B  11      -9.907  -1.883  19.079  1.00 12.36           C  
+ATOM    213  C1'  DA B  11     -11.009  -0.837  19.267  1.00 16.41           C  
+ATOM    214  N9   DA B  11     -10.895  -0.158  20.561  1.00 18.30           N  
+ATOM    215  C8   DA B  11     -10.718  -0.787  21.775  1.00 12.44           C  
+ATOM    216  N7   DA B  11     -10.705   0.020  22.795  1.00 18.24           N  
+ATOM    217  C5   DA B  11     -10.869   1.266  22.226  1.00 17.90           C  
+ATOM    218  C6   DA B  11     -10.952   2.518  22.793  1.00 15.10           C  
+ATOM    219  N6   DA B  11     -10.919   2.716  24.101  1.00 13.54           N  
+ATOM    220  N1   DA B  11     -11.095   3.571  21.975  1.00 16.27           N  
+ATOM    221  C2   DA B  11     -11.181   3.342  20.659  1.00 17.24           C  
+ATOM    222  N3   DA B  11     -11.138   2.195  19.991  1.00 13.64           N  
+ATOM    223  C4   DA B  11     -10.974   1.177  20.848  1.00 16.16           C  
+ATOM    224  P    DA B  12      -9.435  -3.789  16.458  1.00 14.94           P  
+ATOM    225  OP1  DA B  12      -9.943  -4.405  15.206  1.00 17.61           O  
+ATOM    226  OP2  DA B  12      -8.497  -4.550  17.314  1.00 18.50           O  
+ATOM    227  O5'  DA B  12      -8.783  -2.383  16.114  1.00 17.56           O  
+ATOM    228  C5'  DA B  12      -9.447  -1.484  15.234  1.00 18.44           C  
+ATOM    229  C4'  DA B  12      -8.656  -0.207  15.093  1.00 15.29           C  
+ATOM    230  O4'  DA B  12      -8.760   0.577  16.303  1.00 16.60           O  
+ATOM    231  C3'  DA B  12      -7.159  -0.372  14.821  1.00 18.11           C  
+ATOM    232  O3'  DA B  12      -6.742   0.602  13.862  1.00 17.19           O  
+ATOM    233  C2'  DA B  12      -6.528  -0.057  16.164  1.00 17.52           C  
+ATOM    234  C1'  DA B  12      -7.470   1.013  16.682  1.00 16.14           C  
+ATOM    235  N9   DA B  12      -7.470   1.240  18.129  1.00 17.57           N  
+ATOM    236  C8   DA B  12      -7.200   0.351  19.140  1.00 18.61           C  
+ATOM    237  N7   DA B  12      -7.262   0.878  20.336  1.00 18.80           N  
+ATOM    238  C5   DA B  12      -7.602   2.203  20.099  1.00 14.59           C  
+ATOM    239  C6   DA B  12      -7.821   3.294  20.961  1.00 15.40           C  
+ATOM    240  N6   DA B  12      -7.723   3.223  22.298  1.00 17.47           N  
+ATOM    241  N1   DA B  12      -8.148   4.479  20.399  1.00 17.32           N  
+ATOM    242  C2   DA B  12      -8.248   4.549  19.063  1.00 18.52           C  
+ATOM    243  N3   DA B  12      -8.068   3.597  18.155  1.00 17.23           N  
+ATOM    244  C4   DA B  12      -7.741   2.436  18.744  1.00 17.52           C  
+ATOM    245  P    DC B  13      -5.372   0.389  13.051  1.00 15.36           P  
+ATOM    246  OP1  DC B  13      -5.270   1.456  12.022  1.00 16.49           O  
+ATOM    247  OP2  DC B  13      -5.353  -1.032  12.637  1.00 20.64           O  
+ATOM    248  O5'  DC B  13      -4.245   0.619  14.163  1.00 17.63           O  
+ATOM    249  C5'  DC B  13      -3.370   1.748  14.127  1.00 14.81           C  
+ATOM    250  C4'  DC B  13      -4.079   2.979  14.641  1.00 15.32           C  
+ATOM    251  O4'  DC B  13      -4.685   2.724  15.936  1.00 16.87           O  
+ATOM    252  C3'  DC B  13      -3.171   4.195  14.829  1.00 20.65           C  
+ATOM    253  O3'  DC B  13      -3.707   5.358  14.202  1.00 18.31           O  
+ATOM    254  C2'  DC B  13      -3.130   4.401  16.333  1.00 17.92           C  
+ATOM    255  C1'  DC B  13      -4.457   3.836  16.783  1.00 15.53           C  
+ATOM    256  N1   DC B  13      -4.442   3.375  18.189  1.00 18.84           N  
+ATOM    257  C2   DC B  13      -4.721   4.309  19.207  1.00 16.15           C  
+ATOM    258  O2   DC B  13      -5.002   5.485  18.896  1.00 15.94           O  
+ATOM    259  N3   DC B  13      -4.668   3.910  20.503  1.00 14.57           N  
+ATOM    260  C4   DC B  13      -4.347   2.649  20.802  1.00 15.46           C  
+ATOM    261  N4   DC B  13      -4.276   2.311  22.095  1.00 20.68           N  
+ATOM    262  C5   DC B  13      -4.079   1.679  19.790  1.00 16.60           C  
+ATOM    263  C6   DC B  13      -4.142   2.080  18.511  1.00 16.42           C  
+ATOM    264  P    DT B  14      -2.714   6.556  13.795  1.00 13.95           P  
+ATOM    265  OP1  DT B  14      -3.371   7.413  12.777  1.00 14.49           O  
+ATOM    266  OP2  DT B  14      -1.372   5.981  13.524  1.00 17.49           O  
+ATOM    267  O5'  DT B  14      -2.575   7.406  15.129  1.00 14.50           O  
+ATOM    268  C5'  DT B  14      -3.595   8.305  15.516  1.00 17.11           C  
+ATOM    269  C4'  DT B  14      -3.146   9.115  16.706  1.00 16.38           C  
+ATOM    270  O4'  DT B  14      -3.105   8.274  17.880  1.00 16.84           O  
+ATOM    271  C3'  DT B  14      -1.766   9.768  16.586  1.00 16.84           C  
+ATOM    272  O3'  DT B  14      -1.906  11.127  17.016  1.00 16.31           O  
+ATOM    273  C2'  DT B  14      -0.890   8.928  17.513  1.00 18.19           C  
+ATOM    274  C1'  DT B  14      -1.880   8.450  18.567  1.00 15.73           C  
+ATOM    275  N1   DT B  14      -1.594   7.183  19.306  1.00 12.73           N  
+ATOM    276  C2   DT B  14      -1.690   7.217  20.684  1.00 15.39           C  
+ATOM    277  O2   DT B  14      -1.860   8.243  21.323  1.00 12.97           O  
+ATOM    278  N3   DT B  14      -1.558   5.999  21.294  1.00 13.71           N  
+ATOM    279  C4   DT B  14      -1.306   4.785  20.705  1.00 10.92           C  
+ATOM    280  O4   DT B  14      -1.257   3.777  21.393  1.00 13.48           O  
+ATOM    281  C5   DT B  14      -1.134   4.822  19.274  1.00 15.98           C  
+ATOM    282  C7   DT B  14      -0.793   3.554  18.555  1.00 20.28           C  
+ATOM    283  C6   DT B  14      -1.289   6.004  18.650  1.00 18.32           C  
+ATOM    284  P    DT B  15      -0.725  12.189  16.780  1.00 16.07           P  
+ATOM    285  OP1  DT B  15      -1.366  13.512  16.581  1.00 16.75           O  
+ATOM    286  OP2  DT B  15       0.236  11.679  15.770  1.00 19.15           O  
+ATOM    287  O5'  DT B  15      -0.011  12.208  18.204  1.00 18.14           O  
+ATOM    288  C5'  DT B  15      -0.766  12.517  19.362  1.00 18.29           C  
+ATOM    289  C4'  DT B  15       0.029  12.250  20.618  1.00 13.66           C  
+ATOM    290  O4'  DT B  15       0.024  10.847  20.979  1.00 19.85           O  
+ATOM    291  C3'  DT B  15       1.490  12.705  20.639  1.00 14.92           C  
+ATOM    292  O3'  DT B  15       1.678  13.512  21.802  1.00 20.02           O  
+ATOM    293  C2'  DT B  15       2.270  11.401  20.765  1.00 14.89           C  
+ATOM    294  C1'  DT B  15       1.286  10.537  21.536  1.00 12.32           C  
+ATOM    295  N1   DT B  15       1.458   9.060  21.517  1.00 19.11           N  
+ATOM    296  C2   DT B  15       1.364   8.409  22.734  1.00 18.53           C  
+ATOM    297  O2   DT B  15       1.195   8.992  23.790  1.00 12.22           O  
+ATOM    298  N3   DT B  15       1.481   7.044  22.671  1.00 17.23           N  
+ATOM    299  C4   DT B  15       1.691   6.275  21.544  1.00 14.89           C  
+ATOM    300  O4   DT B  15       1.760   5.055  21.649  1.00 19.20           O  
+ATOM    301  C5   DT B  15       1.811   7.017  20.300  1.00 18.68           C  
+ATOM    302  C7   DT B  15       2.069   6.265  19.031  1.00 14.27           C  
+ATOM    303  C6   DT B  15       1.686   8.354  20.347  1.00 16.90           C  
+ATOM    304  P    DC B  16       2.846  14.608  21.847  1.00 15.26           P  
+ATOM    305  OP1  DC B  16       2.259  15.928  22.192  1.00 16.68           O  
+ATOM    306  OP2  DC B  16       3.742  14.475  20.662  1.00 16.11           O  
+ATOM    307  O5'  DC B  16       3.694  14.128  23.085  1.00 16.44           O  
+ATOM    308  C5'  DC B  16       4.153  12.811  23.124  1.00 13.29           C  
+ATOM    309  C4'  DC B  16       4.366  12.395  24.552  1.00 13.05           C  
+ATOM    310  O4'  DC B  16       3.941  11.024  24.639  1.00 12.39           O  
+ATOM    311  C3'  DC B  16       5.835  12.424  24.942  1.00 20.54           C  
+ATOM    312  O3'  DC B  16       5.990  12.882  26.286  1.00 16.67           O  
+ATOM    313  C2'  DC B  16       6.288  10.992  24.741  1.00 15.69           C  
+ATOM    314  C1'  DC B  16       5.023  10.184  24.968  1.00 17.14           C  
+ATOM    315  N1   DC B  16       4.916   8.977  24.134  1.00 15.07           N  
+ATOM    316  C2   DC B  16       4.779   7.746  24.769  1.00 16.18           C  
+ATOM    317  O2   DC B  16       4.671   7.719  26.008  1.00 16.40           O  
+ATOM    318  N3   DC B  16       4.759   6.617  24.027  1.00 19.55           N  
+ATOM    319  C4   DC B  16       4.848   6.688  22.696  1.00 11.23           C  
+ATOM    320  N4   DC B  16       4.842   5.546  22.012  1.00 16.61           N  
+ATOM    321  C5   DC B  16       4.949   7.933  22.013  1.00 14.07           C  
+ATOM    322  C6   DC B  16       4.975   9.047  22.764  1.00 13.22           C  
+ATOM    323  P    DC B  17       7.458  13.230  26.845  1.00 16.29           P  
+ATOM    324  OP1  DC B  17       7.322  14.261  27.894  1.00 14.75           O  
+ATOM    325  OP2  DC B  17       8.393  13.457  25.712  1.00 15.14           O  
+ATOM    326  O5'  DC B  17       7.925  11.870  27.513  1.00 14.68           O  
+ATOM    327  C5'  DC B  17       6.986  10.967  28.080  1.00 14.96           C  
+ATOM    328  C4'  DC B  17       7.703   9.812  28.733  1.00 17.12           C  
+ATOM    329  O4'  DC B  17       7.405   8.604  27.996  1.00 16.18           O  
+ATOM    330  C3'  DC B  17       9.228   9.932  28.780  1.00 16.08           C  
+ATOM    331  O3'  DC B  17       9.708   9.565  30.071  1.00 15.69           O  
+ATOM    332  C2'  DC B  17       9.717   8.960  27.719  1.00 15.18           C  
+ATOM    333  C1'  DC B  17       8.596   7.933  27.619  1.00 15.84           C  
+ATOM    334  N1   DC B  17       8.397   7.391  26.256  1.00 14.23           N  
+ATOM    335  C2   DC B  17       8.285   6.003  26.089  1.00 14.70           C  
+ATOM    336  O2   DC B  17       8.296   5.273  27.090  1.00 12.45           O  
+ATOM    337  N3   DC B  17       8.164   5.492  24.838  1.00 16.91           N  
+ATOM    338  C4   DC B  17       8.142   6.310  23.782  1.00 16.81           C  
+ATOM    339  N4   DC B  17       8.051   5.758  22.567  1.00 15.64           N  
+ATOM    340  C5   DC B  17       8.219   7.727  23.925  1.00 17.07           C  
+ATOM    341  C6   DC B  17       8.343   8.220  25.168  1.00 14.83           C  
+ATOM    342  P    DG B  18      11.166  10.040  30.548  1.00 15.77           P  
+ATOM    343  OP1  DG B  18      11.034  10.651  31.899  1.00 18.65           O  
+ATOM    344  OP2  DG B  18      11.806  10.821  29.449  1.00 16.55           O  
+ATOM    345  O5'  DG B  18      11.922   8.656  30.729  1.00 15.42           O  
+ATOM    346  C5'  DG B  18      11.366   7.651  31.566  1.00 16.83           C  
+ATOM    347  C4'  DG B  18      11.906   6.297  31.181  1.00 19.75           C  
+ATOM    348  O4'  DG B  18      11.524   5.980  29.820  1.00 23.87           O  
+ATOM    349  C3'  DG B  18      13.431   6.181  31.221  1.00 13.52           C  
+ATOM    350  O3'  DG B  18      13.757   4.851  31.639  1.00 19.14           O  
+ATOM    351  C2'  DG B  18      13.815   6.355  29.759  1.00 16.05           C  
+ATOM    352  C1'  DG B  18      12.682   5.594  29.109  1.00 14.86           C  
+ATOM    353  N9   DG B  18      12.444   5.808  27.686  1.00 16.50           N  
+ATOM    354  C8   DG B  18      12.673   6.938  26.939  1.00 16.43           C  
+ATOM    355  N7   DG B  18      12.337   6.794  25.684  1.00 16.56           N  
+ATOM    356  C5   DG B  18      11.860   5.493  25.602  1.00 14.31           C  
+ATOM    357  C6   DG B  18      11.338   4.759  24.493  1.00 16.05           C  
+ATOM    358  O6   DG B  18      11.174   5.136  23.325  1.00 13.47           O  
+ATOM    359  N1   DG B  18      10.979   3.465  24.858  1.00 16.94           N  
+ATOM    360  C2   DG B  18      11.095   2.943  26.125  1.00 17.15           C  
+ATOM    361  N2   DG B  18      10.697   1.673  26.295  1.00 14.06           N  
+ATOM    362  N3   DG B  18      11.566   3.616  27.157  1.00 13.83           N  
+ATOM    363  C4   DG B  18      11.926   4.872  26.827  1.00 13.93           C  
+ATOM    364  P    DG B  19      14.934   4.598  32.701  1.00 12.87           P  
+ATOM    365  OP1  DG B  19      14.272   4.275  33.993  1.00 17.39           O  
+ATOM    366  OP2  DG B  19      15.897   5.721  32.631  1.00 14.95           O  
+ATOM    367  O5'  DG B  19      15.618   3.277  32.137  1.00 16.12           O  
+ATOM    368  C5'  DG B  19      14.880   2.066  32.087  1.00 15.99           C  
+ATOM    369  C4'  DG B  19      15.215   1.267  30.847  1.00 15.13           C  
+ATOM    370  O4'  DG B  19      14.518   1.761  29.665  1.00 16.57           O  
+ATOM    371  C3'  DG B  19      16.697   1.151  30.479  1.00 16.77           C  
+ATOM    372  O3'  DG B  19      17.074  -0.224  30.370  1.00 15.71           O  
+ATOM    373  C2'  DG B  19      16.768   1.791  29.109  1.00 15.89           C  
+ATOM    374  C1'  DG B  19      15.369   1.542  28.553  1.00 14.48           C  
+ATOM    375  N9   DG B  19      15.053   2.496  27.493  1.00 14.79           N  
+ATOM    376  C8   DG B  19      15.207   3.853  27.554  1.00 11.23           C  
+ATOM    377  N7   DG B  19      15.039   4.442  26.406  1.00 18.81           N  
+ATOM    378  C5   DG B  19      14.704   3.416  25.535  1.00 16.67           C  
+ATOM    379  C6   DG B  19      14.429   3.451  24.138  1.00 15.96           C  
+ATOM    380  O6   DG B  19      14.446   4.427  23.375  1.00 16.48           O  
+ATOM    381  N1   DG B  19      14.123   2.186  23.645  1.00 18.44           N  
+ATOM    382  C2   DG B  19      14.091   1.037  24.394  1.00 15.48           C  
+ATOM    383  N2   DG B  19      13.773  -0.085  23.737  1.00 16.44           N  
+ATOM    384  N3   DG B  19      14.352   0.990  25.697  1.00 13.59           N  
+ATOM    385  C4   DG B  19      14.656   2.211  26.198  1.00 17.11           C  
+ATOM    386  P    DT B  20      18.558  -0.628  29.880  1.00 18.03           P  
+ATOM    387  OP1  DT B  20      19.093  -1.612  30.860  1.00 16.92           O  
+ATOM    388  OP2  DT B  20      19.359   0.577  29.549  1.00 17.99           O  
+ATOM    389  O5'  DT B  20      18.278  -1.397  28.509  1.00 15.64           O  
+ATOM    390  C5'  DT B  20      17.371  -2.500  28.462  1.00 17.03           C  
+ATOM    391  C4'  DT B  20      17.458  -3.202  27.125  1.00 20.42           C  
+ATOM    392  O4'  DT B  20      16.921  -2.338  26.091  1.00 11.45           O  
+ATOM    393  C3'  DT B  20      18.870  -3.588  26.675  1.00 15.71           C  
+ATOM    394  O3'  DT B  20      18.878  -4.760  25.881  1.00 14.73           O  
+ATOM    395  C2'  DT B  20      19.255  -2.469  25.727  1.00 15.53           C  
+ATOM    396  C1'  DT B  20      17.917  -2.075  25.104  1.00 16.62           C  
+ATOM    397  N1   DT B  20      17.828  -0.639  24.740  1.00 18.13           N  
+ATOM    398  C2   DT B  20      17.473  -0.302  23.449  1.00 16.84           C  
+ATOM    399  O2   DT B  20      17.233  -1.129  22.581  1.00 15.13           O  
+ATOM    400  N3   DT B  20      17.413   1.050  23.213  1.00 13.45           N  
+ATOM    401  C4   DT B  20      17.677   2.071  24.108  1.00 17.41           C  
+ATOM    402  O4   DT B  20      17.588   3.243  23.750  1.00 17.34           O  
+ATOM    403  C5   DT B  20      18.053   1.644  25.435  1.00 13.29           C  
+ATOM    404  C7   DT B  20      18.376   2.676  26.470  1.00 14.14           C  
+ATOM    405  C6   DT B  20      18.102   0.333  25.680  1.00 16.54           C  
+TER     406       DT B  20                                                      
+ATOM    407  N   MET C   1     -14.358  13.416   9.007  1.00 48.14           N  
+ATOM    408  CA  MET C   1     -14.660  12.744   7.707  1.00 47.68           C  
+ATOM    409  C   MET C   1     -13.362  12.270   7.055  1.00 47.33           C  
+ATOM    410  O   MET C   1     -13.026  12.659   5.930  1.00 48.04           O  
+ATOM    411  CB  MET C   1     -15.401  13.710   6.770  1.00 48.84           C  
+ATOM    412  CG  MET C   1     -15.913  13.080   5.475  1.00 50.02           C  
+ATOM    413  SD  MET C   1     -15.697  14.169   4.032  1.00 53.05           S  
+ATOM    414  CE  MET C   1     -14.142  13.511   3.314  1.00 50.78           C  
+ATOM    415  N   ASP C   2     -12.633  11.425   7.779  1.00 45.55           N  
+ATOM    416  CA  ASP C   2     -11.368  10.876   7.296  1.00 43.31           C  
+ATOM    417  C   ASP C   2     -11.590   9.499   6.655  1.00 41.91           C  
+ATOM    418  O   ASP C   2     -12.731   9.052   6.492  1.00 42.52           O  
+ATOM    419  CB  ASP C   2     -10.383  10.751   8.465  1.00 41.90           C  
+ATOM    420  CG  ASP C   2     -11.014  10.104   9.689  1.00 41.75           C  
+ATOM    421  OD1 ASP C   2     -11.913  10.727  10.300  1.00 41.03           O  
+ATOM    422  OD2 ASP C   2     -10.611   8.972  10.039  1.00 40.75           O  
+ATOM    423  N   SER C   3     -10.499   8.834   6.284  1.00 40.22           N  
+ATOM    424  CA  SER C   3     -10.591   7.502   5.691  1.00 37.78           C  
+ATOM    425  C   SER C   3     -10.700   6.479   6.821  1.00 36.38           C  
+ATOM    426  O   SER C   3      -9.978   6.570   7.826  1.00 36.39           O  
+ATOM    427  CB  SER C   3      -9.352   7.205   4.842  1.00 37.24           C  
+ATOM    428  OG  SER C   3      -9.441   5.927   4.236  1.00 36.02           O  
+ATOM    429  N   ALA C   4     -11.609   5.518   6.662  1.00 33.88           N  
+ATOM    430  CA  ALA C   4     -11.808   4.473   7.667  1.00 31.57           C  
+ATOM    431  C   ALA C   4     -10.742   3.401   7.494  1.00 29.65           C  
+ATOM    432  O   ALA C   4     -10.769   2.359   8.155  1.00 29.38           O  
+ATOM    433  CB  ALA C   4     -13.172   3.858   7.504  1.00 31.46           C  
+ATOM    434  N   ILE C   5      -9.810   3.666   6.585  1.00 27.46           N  
+ATOM    435  CA  ILE C   5      -8.735   2.739   6.294  1.00 24.88           C  
+ATOM    436  C   ILE C   5      -7.933   2.403   7.549  1.00 23.07           C  
+ATOM    437  O   ILE C   5      -7.698   3.252   8.412  1.00 23.24           O  
+ATOM    438  CB  ILE C   5      -7.786   3.318   5.197  1.00 25.14           C  
+ATOM    439  CG1 ILE C   5      -6.706   2.299   4.840  1.00 24.63           C  
+ATOM    440  CG2 ILE C   5      -7.151   4.615   5.676  1.00 25.14           C  
+ATOM    441  CD1 ILE C   5      -7.022   1.487   3.626  1.00 25.13           C  
+ATOM    442  N   THR C   6      -7.537   1.141   7.630  1.00 19.71           N  
+ATOM    443  CA  THR C   6      -6.743   0.612   8.726  1.00 18.05           C  
+ATOM    444  C   THR C   6      -5.270   0.853   8.347  1.00 16.47           C  
+ATOM    445  O   THR C   6      -4.983   1.093   7.175  1.00 15.38           O  
+ATOM    446  CB  THR C   6      -7.047  -0.888   8.862  1.00 17.62           C  
+ATOM    447  OG1 THR C   6      -7.414  -1.185  10.210  1.00 20.34           O  
+ATOM    448  CG2 THR C   6      -5.878  -1.713   8.448  1.00 16.14           C  
+ATOM    449  N   LEU C   7      -4.339   0.805   9.302  1.00 14.83           N  
+ATOM    450  CA  LEU C   7      -2.934   1.042   8.934  1.00 13.70           C  
+ATOM    451  C   LEU C   7      -2.346  -0.105   8.111  1.00 12.67           C  
+ATOM    452  O   LEU C   7      -1.597   0.127   7.163  1.00 13.35           O  
+ATOM    453  CB  LEU C   7      -2.043   1.295  10.167  1.00 13.14           C  
+ATOM    454  CG  LEU C   7      -0.515   1.289   9.918  1.00 12.58           C  
+ATOM    455  CD1 LEU C   7      -0.103   2.535   9.145  1.00 11.31           C  
+ATOM    456  CD2 LEU C   7       0.243   1.212  11.254  1.00 11.96           C  
+ATOM    457  N   TRP C   8      -2.672  -1.342   8.456  1.00 12.37           N  
+ATOM    458  CA  TRP C   8      -2.122  -2.445   7.691  1.00 11.96           C  
+ATOM    459  C   TRP C   8      -2.766  -2.496   6.303  1.00 11.14           C  
+ATOM    460  O   TRP C   8      -2.176  -3.028   5.373  1.00 10.62           O  
+ATOM    461  CB  TRP C   8      -2.280  -3.780   8.438  1.00 12.42           C  
+ATOM    462  CG  TRP C   8      -3.690  -4.241   8.644  1.00 14.71           C  
+ATOM    463  CD1 TRP C   8      -4.428  -4.130   9.789  1.00 13.68           C  
+ATOM    464  CD2 TRP C   8      -4.539  -4.884   7.677  1.00 15.24           C  
+ATOM    465  NE1 TRP C   8      -5.687  -4.661   9.596  1.00 14.95           N  
+ATOM    466  CE2 TRP C   8      -5.782  -5.132   8.310  1.00 15.66           C  
+ATOM    467  CE3 TRP C   8      -4.370  -5.273   6.339  1.00 14.21           C  
+ATOM    468  CZ2 TRP C   8      -6.853  -5.753   7.649  1.00 15.13           C  
+ATOM    469  CZ3 TRP C   8      -5.434  -5.890   5.682  1.00 15.09           C  
+ATOM    470  CH2 TRP C   8      -6.659  -6.122   6.339  1.00 15.89           C  
+ATOM    471  N   GLN C   9      -3.956  -1.915   6.159  1.00 10.26           N  
+ATOM    472  CA  GLN C   9      -4.644  -1.901   4.861  1.00 11.58           C  
+ATOM    473  C   GLN C   9      -4.031  -0.811   3.997  1.00 12.02           C  
+ATOM    474  O   GLN C   9      -3.926  -0.942   2.779  1.00 12.36           O  
+ATOM    475  CB  GLN C   9      -6.130  -1.592   5.022  1.00 12.48           C  
+ATOM    476  CG  GLN C   9      -6.971  -2.692   5.623  1.00 13.65           C  
+ATOM    477  CD  GLN C   9      -8.365  -2.194   5.989  1.00 14.77           C  
+ATOM    478  OE1 GLN C   9      -8.672  -1.014   5.829  1.00 14.89           O  
+ATOM    479  NE2 GLN C   9      -9.213  -3.090   6.475  1.00 16.11           N  
+ATOM    480  N   PHE C  10      -3.644   0.277   4.654  1.00 12.02           N  
+ATOM    481  CA  PHE C  10      -3.032   1.420   4.001  1.00 12.30           C  
+ATOM    482  C   PHE C  10      -1.670   1.009   3.451  1.00 12.37           C  
+ATOM    483  O   PHE C  10      -1.290   1.417   2.357  1.00 11.81           O  
+ATOM    484  CB  PHE C  10      -2.889   2.559   5.010  1.00 12.03           C  
+ATOM    485  CG  PHE C  10      -2.050   3.708   4.530  1.00 13.06           C  
+ATOM    486  CD1 PHE C  10      -2.574   4.651   3.657  1.00 13.40           C  
+ATOM    487  CD2 PHE C  10      -0.740   3.863   4.977  1.00 12.38           C  
+ATOM    488  CE1 PHE C  10      -1.805   5.734   3.239  1.00 13.80           C  
+ATOM    489  CE2 PHE C  10       0.036   4.942   4.567  1.00 12.21           C  
+ATOM    490  CZ  PHE C  10      -0.491   5.875   3.701  1.00 13.42           C  
+ATOM    491  N   LEU C  11      -0.944   0.193   4.211  1.00 11.56           N  
+ATOM    492  CA  LEU C  11       0.369  -0.277   3.776  1.00 11.48           C  
+ATOM    493  C   LEU C  11       0.181  -1.185   2.575  1.00 12.32           C  
+ATOM    494  O   LEU C  11       0.926  -1.104   1.598  1.00 11.73           O  
+ATOM    495  CB  LEU C  11       1.061  -1.031   4.908  1.00 10.56           C  
+ATOM    496  CG  LEU C  11       1.430  -0.088   6.057  1.00 10.59           C  
+ATOM    497  CD1 LEU C  11       2.062  -0.884   7.184  1.00 10.95           C  
+ATOM    498  CD2 LEU C  11       2.381   1.011   5.546  1.00 10.23           C  
+ATOM    499  N   LEU C  12      -0.833  -2.043   2.660  1.00 12.43           N  
+ATOM    500  CA  LEU C  12      -1.168  -2.966   1.583  1.00 13.65           C  
+ATOM    501  C   LEU C  12      -1.523  -2.162   0.331  1.00 13.79           C  
+ATOM    502  O   LEU C  12      -1.217  -2.566  -0.785  1.00 15.40           O  
+ATOM    503  CB  LEU C  12      -2.357  -3.847   1.999  1.00 13.90           C  
+ATOM    504  CG  LEU C  12      -2.180  -5.372   2.114  1.00 14.96           C  
+ATOM    505  CD1 LEU C  12      -0.756  -5.749   2.541  1.00 14.23           C  
+ATOM    506  CD2 LEU C  12      -3.200  -5.907   3.101  1.00 13.90           C  
+ATOM    507  N   GLN C  13      -2.155  -1.015   0.517  1.00 14.28           N  
+ATOM    508  CA  GLN C  13      -2.525  -0.179  -0.615  1.00 16.00           C  
+ATOM    509  C   GLN C  13      -1.292   0.389  -1.324  1.00 15.46           C  
+ATOM    510  O   GLN C  13      -1.210   0.358  -2.554  1.00 14.97           O  
+ATOM    511  CB  GLN C  13      -3.443   0.955  -0.153  1.00 18.13           C  
+ATOM    512  CG  GLN C  13      -4.773   1.019  -0.905  1.00 22.10           C  
+ATOM    513  CD  GLN C  13      -5.982   1.226   0.013  1.00 24.06           C  
+ATOM    514  OE1 GLN C  13      -6.947   0.447  -0.022  1.00 25.48           O  
+ATOM    515  NE2 GLN C  13      -5.936   2.280   0.834  1.00 24.49           N  
+ATOM    516  N   LEU C  14      -0.335   0.897  -0.549  1.00 14.25           N  
+ATOM    517  CA  LEU C  14       0.901   1.459  -1.108  1.00 13.32           C  
+ATOM    518  C   LEU C  14       1.700   0.372  -1.809  1.00 13.33           C  
+ATOM    519  O   LEU C  14       2.312   0.602  -2.858  1.00 12.12           O  
+ATOM    520  CB  LEU C  14       1.768   2.084   0.001  1.00 12.53           C  
+ATOM    521  CG  LEU C  14       1.167   3.283   0.744  1.00 12.36           C  
+ATOM    522  CD1 LEU C  14       2.045   3.674   1.912  1.00 11.75           C  
+ATOM    523  CD2 LEU C  14       1.014   4.454  -0.215  1.00 13.50           C  
+ATOM    524  N   LEU C  15       1.689  -0.816  -1.217  1.00 12.74           N  
+ATOM    525  CA  LEU C  15       2.410  -1.956  -1.759  1.00 13.71           C  
+ATOM    526  C   LEU C  15       1.807  -2.461  -3.092  1.00 14.78           C  
+ATOM    527  O   LEU C  15       2.419  -3.262  -3.791  1.00 14.32           O  
+ATOM    528  CB  LEU C  15       2.413  -3.084  -0.723  1.00 12.89           C  
+ATOM    529  CG  LEU C  15       3.675  -3.555   0.025  1.00 12.15           C  
+ATOM    530  CD1 LEU C  15       4.879  -2.696  -0.284  1.00 11.12           C  
+ATOM    531  CD2 LEU C  15       3.391  -3.570   1.516  1.00 11.61           C  
+ATOM    532  N   GLN C  16       0.615  -1.991  -3.438  1.00 15.88           N  
+ATOM    533  CA  GLN C  16      -0.045  -2.417  -4.672  1.00 18.12           C  
+ATOM    534  C   GLN C  16       0.300  -1.509  -5.867  1.00 18.00           C  
+ATOM    535  O   GLN C  16       0.163  -1.903  -7.024  1.00 18.24           O  
+ATOM    536  CB  GLN C  16      -1.564  -2.440  -4.445  1.00 21.41           C  
+ATOM    537  CG  GLN C  16      -2.386  -3.234  -5.465  1.00 26.16           C  
+ATOM    538  CD  GLN C  16      -1.803  -4.615  -5.775  1.00 29.74           C  
+ATOM    539  OE1 GLN C  16      -1.380  -5.348  -4.875  1.00 32.32           O  
+ATOM    540  NE2 GLN C  16      -1.788  -4.975  -7.058  1.00 30.30           N  
+ATOM    541  N   LYS C  17       0.766  -0.300  -5.581  1.00 18.05           N  
+ATOM    542  CA  LYS C  17       1.094   0.654  -6.628  1.00 17.81           C  
+ATOM    543  C   LYS C  17       2.595   0.875  -6.823  1.00 16.99           C  
+ATOM    544  O   LYS C  17       3.308   1.257  -5.893  1.00 15.88           O  
+ATOM    545  CB  LYS C  17       0.406   1.987  -6.327  1.00 18.91           C  
+ATOM    546  CG  LYS C  17      -1.072   1.848  -6.028  1.00 20.88           C  
+ATOM    547  CD  LYS C  17      -1.866   1.588  -7.302  1.00 22.33           C  
+ATOM    548  CE  LYS C  17      -3.276   1.100  -6.998  1.00 21.94           C  
+ATOM    549  NZ  LYS C  17      -4.145   2.220  -6.568  1.00 24.52           N  
+ATOM    550  N   PRO C  18       3.088   0.651  -8.056  1.00 16.53           N  
+ATOM    551  CA  PRO C  18       4.506   0.820  -8.397  1.00 15.39           C  
+ATOM    552  C   PRO C  18       5.018   2.202  -8.032  1.00 13.18           C  
+ATOM    553  O   PRO C  18       6.188   2.374  -7.705  1.00 12.91           O  
+ATOM    554  CB  PRO C  18       4.548   0.585  -9.910  1.00 16.16           C  
+ATOM    555  CG  PRO C  18       3.347  -0.239 -10.195  1.00 17.25           C  
+ATOM    556  CD  PRO C  18       2.294   0.237  -9.227  1.00 17.73           C  
+ATOM    557  N   GLN C  19       4.128   3.184  -8.093  1.00 12.58           N  
+ATOM    558  CA  GLN C  19       4.476   4.559  -7.780  1.00 13.24           C  
+ATOM    559  C   GLN C  19       5.068   4.718  -6.385  1.00 13.21           C  
+ATOM    560  O   GLN C  19       5.790   5.683  -6.128  1.00 12.78           O  
+ATOM    561  CB  GLN C  19       3.245   5.459  -7.886  1.00 14.67           C  
+ATOM    562  CG  GLN C  19       2.343   5.148  -9.064  1.00 19.09           C  
+ATOM    563  CD  GLN C  19       1.169   4.256  -8.696  1.00 20.01           C  
+ATOM    564  OE1 GLN C  19       1.171   3.059  -8.993  1.00 19.64           O  
+ATOM    565  NE2 GLN C  19       0.156   4.837  -8.051  1.00 20.47           N  
+ATOM    566  N   ASN C  20       4.756   3.785  -5.489  1.00 12.67           N  
+ATOM    567  CA  ASN C  20       5.246   3.857  -4.110  1.00 12.68           C  
+ATOM    568  C   ASN C  20       6.346   2.871  -3.777  1.00 13.13           C  
+ATOM    569  O   ASN C  20       6.733   2.745  -2.610  1.00 13.10           O  
+ATOM    570  CB  ASN C  20       4.089   3.646  -3.133  1.00 12.27           C  
+ATOM    571  CG  ASN C  20       2.858   4.419  -3.522  1.00 11.64           C  
+ATOM    572  OD1 ASN C  20       2.827   5.640  -3.418  1.00 12.43           O  
+ATOM    573  ND2 ASN C  20       1.832   3.710  -3.974  1.00 11.23           N  
+ATOM    574  N   LYS C  21       6.839   2.163  -4.791  1.00 12.56           N  
+ATOM    575  CA  LYS C  21       7.899   1.180  -4.591  1.00 12.71           C  
+ATOM    576  C   LYS C  21       9.150   1.832  -4.004  1.00 12.06           C  
+ATOM    577  O   LYS C  21       9.897   1.197  -3.257  1.00 12.10           O  
+ATOM    578  CB  LYS C  21       8.251   0.503  -5.916  1.00 14.24           C  
+ATOM    579  CG  LYS C  21       8.017  -0.989  -5.936  1.00 17.58           C  
+ATOM    580  CD  LYS C  21       8.761  -1.624  -7.093  1.00 18.54           C  
+ATOM    581  CE  LYS C  21      10.218  -1.875  -6.713  1.00 20.06           C  
+ATOM    582  NZ  LYS C  21      10.382  -3.147  -5.954  1.00 21.36           N  
+ATOM    583  N   HIS C  22       9.378   3.098  -4.334  1.00 11.26           N  
+ATOM    584  CA  HIS C  22      10.550   3.795  -3.815  1.00 11.41           C  
+ATOM    585  C   HIS C  22      10.450   4.075  -2.319  1.00 10.93           C  
+ATOM    586  O   HIS C  22      11.466   4.326  -1.680  1.00 10.91           O  
+ATOM    587  CB  HIS C  22      10.776   5.119  -4.547  1.00  9.28           C  
+ATOM    588  CG  HIS C  22       9.704   6.129  -4.298  1.00  9.58           C  
+ATOM    589  ND1 HIS C  22       8.481   6.080  -4.928  1.00  9.37           N  
+ATOM    590  CD2 HIS C  22       9.672   7.221  -3.501  1.00  8.54           C  
+ATOM    591  CE1 HIS C  22       7.742   7.098  -4.534  1.00  7.65           C  
+ATOM    592  NE2 HIS C  22       8.440   7.806  -3.666  1.00  7.72           N  
+ATOM    593  N   MET C  23       9.241   4.039  -1.756  1.00 10.59           N  
+ATOM    594  CA  MET C  23       9.090   4.302  -0.325  1.00  9.82           C  
+ATOM    595  C   MET C  23       8.722   3.068   0.499  1.00 10.39           C  
+ATOM    596  O   MET C  23       8.972   3.021   1.713  1.00  9.33           O  
+ATOM    597  CB  MET C  23       8.077   5.430  -0.094  1.00 10.40           C  
+ATOM    598  CG  MET C  23       6.630   5.021  -0.136  1.00 10.96           C  
+ATOM    599  SD  MET C  23       5.578   6.442   0.245  1.00 12.43           S  
+ATOM    600  CE  MET C  23       5.563   7.290  -1.388  1.00 12.88           C  
+ATOM    601  N   ILE C  24       8.132   2.075  -0.158  1.00 10.11           N  
+ATOM    602  CA  ILE C  24       7.755   0.821   0.492  1.00 10.87           C  
+ATOM    603  C   ILE C  24       7.678  -0.280  -0.570  1.00 11.19           C  
+ATOM    604  O   ILE C  24       6.964  -0.156  -1.564  1.00 11.01           O  
+ATOM    605  CB  ILE C  24       6.405   0.948   1.257  1.00 10.16           C  
+ATOM    606  CG1 ILE C  24       6.038  -0.401   1.885  1.00 10.04           C  
+ATOM    607  CG2 ILE C  24       5.318   1.458   0.334  1.00 11.05           C  
+ATOM    608  CD1 ILE C  24       4.928  -0.323   2.935  1.00 10.49           C  
+ATOM    609  N   CYS C  25       8.434  -1.354  -0.367  1.00 11.32           N  
+ATOM    610  CA  CYS C  25       8.470  -2.438  -1.343  1.00 11.83           C  
+ATOM    611  C   CYS C  25       8.447  -3.820  -0.703  1.00 12.69           C  
+ATOM    612  O   CYS C  25       8.791  -3.980   0.470  1.00 13.01           O  
+ATOM    613  CB  CYS C  25       9.736  -2.306  -2.189  1.00 12.02           C  
+ATOM    614  SG  CYS C  25      11.265  -2.574  -1.211  1.00 13.67           S  
+ATOM    615  N   TRP C  26       8.031  -4.821  -1.474  1.00 12.71           N  
+ATOM    616  CA  TRP C  26       8.006  -6.191  -0.972  1.00 12.43           C  
+ATOM    617  C   TRP C  26       9.446  -6.677  -1.057  1.00 12.97           C  
+ATOM    618  O   TRP C  26      10.159  -6.364  -2.021  1.00 11.73           O  
+ATOM    619  CB  TRP C  26       7.124  -7.096  -1.846  1.00 11.87           C  
+ATOM    620  CG  TRP C  26       5.648  -6.831  -1.770  1.00 12.13           C  
+ATOM    621  CD1 TRP C  26       4.856  -6.327  -2.764  1.00 12.17           C  
+ATOM    622  CD2 TRP C  26       4.774  -7.121  -0.670  1.00 11.94           C  
+ATOM    623  NE1 TRP C  26       3.543  -6.290  -2.354  1.00 12.73           N  
+ATOM    624  CE2 TRP C  26       3.462  -6.772  -1.074  1.00 12.33           C  
+ATOM    625  CE3 TRP C  26       4.971  -7.644   0.620  1.00 11.12           C  
+ATOM    626  CZ2 TRP C  26       2.347  -6.929  -0.235  1.00 11.66           C  
+ATOM    627  CZ3 TRP C  26       3.862  -7.801   1.455  1.00 10.62           C  
+ATOM    628  CH2 TRP C  26       2.565  -7.443   1.020  1.00 11.37           C  
+ATOM    629  N   THR C  27       9.876  -7.430  -0.052  1.00 13.09           N  
+ATOM    630  CA  THR C  27      11.232  -7.957  -0.026  1.00 14.65           C  
+ATOM    631  C   THR C  27      11.215  -9.474  -0.020  1.00 15.30           C  
+ATOM    632  O   THR C  27      12.252 -10.122   0.112  1.00 14.68           O  
+ATOM    633  CB  THR C  27      11.998  -7.461   1.202  1.00 13.89           C  
+ATOM    634  OG1 THR C  27      11.241  -7.735   2.378  1.00 15.65           O  
+ATOM    635  CG2 THR C  27      12.227  -5.974   1.105  1.00 14.44           C  
+ATOM    636  N   SER C  28      10.022 -10.040  -0.159  1.00 15.80           N  
+ATOM    637  CA  SER C  28       9.868 -11.486  -0.203  1.00 16.47           C  
+ATOM    638  C   SER C  28       8.556 -11.828  -0.896  1.00 16.94           C  
+ATOM    639  O   SER C  28       7.742 -10.939  -1.162  1.00 16.98           O  
+ATOM    640  CB  SER C  28       9.878 -12.075   1.214  1.00 17.89           C  
+ATOM    641  OG  SER C  28       8.560 -12.287   1.707  1.00 15.83           O  
+ATOM    642  N   ASN C  29       8.365 -13.114  -1.195  1.00 17.88           N  
+ATOM    643  CA  ASN C  29       7.139 -13.584  -1.834  1.00 18.92           C  
+ATOM    644  C   ASN C  29       6.224 -14.245  -0.796  1.00 19.46           C  
+ATOM    645  O   ASN C  29       5.378 -15.085  -1.139  1.00 19.01           O  
+ATOM    646  CB  ASN C  29       7.459 -14.574  -2.957  1.00 20.55           C  
+ATOM    647  CG  ASN C  29       8.071 -15.859  -2.444  1.00 22.02           C  
+ATOM    648  OD1 ASN C  29       8.587 -15.917  -1.323  1.00 23.49           O  
+ATOM    649  ND2 ASN C  29       8.021 -16.903  -3.267  1.00 23.01           N  
+ATOM    650  N   ASP C  30       6.406 -13.875   0.475  1.00 19.08           N  
+ATOM    651  CA  ASP C  30       5.564 -14.422   1.534  1.00 18.88           C  
+ATOM    652  C   ASP C  30       5.128 -13.409   2.596  1.00 18.10           C  
+ATOM    653  O   ASP C  30       4.908 -13.765   3.757  1.00 18.10           O  
+ATOM    654  CB  ASP C  30       6.231 -15.651   2.175  1.00 20.05           C  
+ATOM    655  CG  ASP C  30       7.444 -15.311   3.025  1.00 19.64           C  
+ATOM    656  OD1 ASP C  30       7.927 -14.158   2.975  1.00 19.75           O  
+ATOM    657  OD2 ASP C  30       7.914 -16.223   3.747  1.00 20.86           O  
+ATOM    658  N   GLY C  31       5.001 -12.145   2.190  1.00 17.67           N  
+ATOM    659  CA  GLY C  31       4.542 -11.109   3.104  1.00 15.78           C  
+ATOM    660  C   GLY C  31       5.525 -10.097   3.664  1.00 15.01           C  
+ATOM    661  O   GLY C  31       5.108  -9.128   4.297  1.00 15.54           O  
+ATOM    662  N   GLN C  32       6.816 -10.309   3.436  1.00 14.35           N  
+ATOM    663  CA  GLN C  32       7.860  -9.414   3.937  1.00 13.67           C  
+ATOM    664  C   GLN C  32       7.968  -8.122   3.119  1.00 13.33           C  
+ATOM    665  O   GLN C  32       7.941  -8.145   1.888  1.00 11.91           O  
+ATOM    666  CB  GLN C  32       9.194 -10.149   3.912  1.00 14.92           C  
+ATOM    667  CG  GLN C  32      10.215  -9.669   4.912  1.00 18.62           C  
+ATOM    668  CD  GLN C  32      11.237 -10.743   5.233  1.00 19.87           C  
+ATOM    669  OE1 GLN C  32      10.899 -11.921   5.369  1.00 22.44           O  
+ATOM    670  NE2 GLN C  32      12.492 -10.344   5.352  1.00 22.35           N  
+ATOM    671  N   PHE C  33       8.091  -6.992   3.803  1.00 12.08           N  
+ATOM    672  CA  PHE C  33       8.195  -5.713   3.119  1.00 11.28           C  
+ATOM    673  C   PHE C  33       9.123  -4.791   3.883  1.00 11.58           C  
+ATOM    674  O   PHE C  33       9.396  -5.025   5.056  1.00 11.41           O  
+ATOM    675  CB  PHE C  33       6.806  -5.067   2.958  1.00 10.42           C  
+ATOM    676  CG  PHE C  33       6.147  -4.669   4.263  1.00  9.28           C  
+ATOM    677  CD1 PHE C  33       5.426  -5.603   5.010  1.00  9.59           C  
+ATOM    678  CD2 PHE C  33       6.239  -3.360   4.736  1.00  9.03           C  
+ATOM    679  CE1 PHE C  33       4.803  -5.233   6.223  1.00  7.34           C  
+ATOM    680  CE2 PHE C  33       5.622  -2.980   5.941  1.00  8.14           C  
+ATOM    681  CZ  PHE C  33       4.905  -3.920   6.680  1.00  7.02           C  
+ATOM    682  N   LYS C  34       9.606  -3.748   3.211  1.00 11.68           N  
+ATOM    683  CA  LYS C  34      10.522  -2.791   3.819  1.00 11.90           C  
+ATOM    684  C   LYS C  34      10.136  -1.342   3.532  1.00 12.16           C  
+ATOM    685  O   LYS C  34       9.821  -0.972   2.391  1.00 10.80           O  
+ATOM    686  CB  LYS C  34      11.948  -3.057   3.317  1.00 12.29           C  
+ATOM    687  CG  LYS C  34      12.983  -2.010   3.717  1.00 13.19           C  
+ATOM    688  CD  LYS C  34      14.400  -2.485   3.373  1.00 14.49           C  
+ATOM    689  CE  LYS C  34      15.466  -1.542   3.917  1.00 15.79           C  
+ATOM    690  NZ  LYS C  34      14.892  -0.296   4.508  1.00 16.74           N  
+ATOM    691  N   LEU C  35      10.147  -0.527   4.587  1.00 12.51           N  
+ATOM    692  CA  LEU C  35       9.837   0.890   4.475  1.00 12.86           C  
+ATOM    693  C   LEU C  35      11.118   1.607   4.045  1.00 13.32           C  
+ATOM    694  O   LEU C  35      11.896   2.086   4.884  1.00 13.56           O  
+ATOM    695  CB  LEU C  35       9.357   1.438   5.823  1.00 14.11           C  
+ATOM    696  CG  LEU C  35       8.166   0.710   6.442  1.00 14.11           C  
+ATOM    697  CD1 LEU C  35       8.080   1.046   7.927  1.00 14.99           C  
+ATOM    698  CD2 LEU C  35       6.896   1.121   5.718  1.00 13.04           C  
+ATOM    699  N   LEU C  36      11.337   1.666   2.731  1.00 12.82           N  
+ATOM    700  CA  LEU C  36      12.523   2.307   2.177  1.00 11.99           C  
+ATOM    701  C   LEU C  36      12.591   3.754   2.608  1.00 10.86           C  
+ATOM    702  O   LEU C  36      13.658   4.253   2.933  1.00 10.61           O  
+ATOM    703  CB  LEU C  36      12.515   2.218   0.648  1.00 11.33           C  
+ATOM    704  CG  LEU C  36      12.502   0.813   0.049  1.00 12.80           C  
+ATOM    705  CD1 LEU C  36      12.661   0.920  -1.458  1.00 12.15           C  
+ATOM    706  CD2 LEU C  36      13.636  -0.029   0.637  1.00 13.59           C  
+ATOM    707  N   GLN C  37      11.441   4.422   2.595  1.00 11.05           N  
+ATOM    708  CA  GLN C  37      11.324   5.820   2.996  1.00 11.01           C  
+ATOM    709  C   GLN C  37      10.264   5.872   4.111  1.00 11.31           C  
+ATOM    710  O   GLN C  37       9.114   6.265   3.882  1.00 10.23           O  
+ATOM    711  CB  GLN C  37      10.878   6.668   1.800  1.00 11.79           C  
+ATOM    712  CG  GLN C  37      11.854   6.672   0.630  1.00 14.11           C  
+ATOM    713  CD  GLN C  37      13.223   7.238   0.990  1.00 15.46           C  
+ATOM    714  OE1 GLN C  37      14.246   6.780   0.477  1.00 17.23           O  
+ATOM    715  NE2 GLN C  37      13.249   8.241   1.872  1.00 15.64           N  
+ATOM    716  N   ALA C  38      10.682   5.474   5.314  1.00 12.36           N  
+ATOM    717  CA  ALA C  38       9.828   5.395   6.496  1.00 11.58           C  
+ATOM    718  C   ALA C  38       9.088   6.667   6.895  1.00 11.57           C  
+ATOM    719  O   ALA C  38       7.893   6.616   7.199  1.00 12.20           O  
+ATOM    720  CB  ALA C  38      10.640   4.880   7.663  1.00 12.17           C  
+ATOM    721  N   GLU C  39       9.785   7.801   6.900  1.00 10.34           N  
+ATOM    722  CA  GLU C  39       9.163   9.073   7.247  1.00 10.03           C  
+ATOM    723  C   GLU C  39       8.218   9.536   6.129  1.00 10.28           C  
+ATOM    724  O   GLU C  39       7.218  10.212   6.385  1.00  8.56           O  
+ATOM    725  CB  GLU C  39      10.238  10.130   7.494  1.00 10.80           C  
+ATOM    726  CG  GLU C  39      11.127   9.827   8.695  1.00 11.58           C  
+ATOM    727  CD  GLU C  39      10.352   9.745  10.013  1.00 12.52           C  
+ATOM    728  OE1 GLU C  39       9.162  10.112  10.040  1.00 12.74           O  
+ATOM    729  OE2 GLU C  39      10.943   9.313  11.023  1.00 12.35           O  
+ATOM    730  N   GLU C  40       8.537   9.187   4.883  1.00 10.18           N  
+ATOM    731  CA  GLU C  40       7.668   9.576   3.785  1.00 10.19           C  
+ATOM    732  C   GLU C  40       6.354   8.786   3.881  1.00  9.86           C  
+ATOM    733  O   GLU C  40       5.276   9.342   3.668  1.00 10.62           O  
+ATOM    734  CB  GLU C  40       8.337   9.333   2.428  1.00  8.63           C  
+ATOM    735  CG  GLU C  40       7.468   9.825   1.292  1.00  8.66           C  
+ATOM    736  CD  GLU C  40       8.092   9.654  -0.079  1.00  8.32           C  
+ATOM    737  OE1 GLU C  40       9.163   9.016  -0.205  1.00  7.48           O  
+ATOM    738  OE2 GLU C  40       7.495  10.178  -1.038  1.00  9.73           O  
+ATOM    739  N   VAL C  41       6.441   7.498   4.213  1.00 10.29           N  
+ATOM    740  CA  VAL C  41       5.245   6.659   4.362  1.00  9.15           C  
+ATOM    741  C   VAL C  41       4.414   7.203   5.534  1.00 10.06           C  
+ATOM    742  O   VAL C  41       3.185   7.242   5.464  1.00  9.64           O  
+ATOM    743  CB  VAL C  41       5.610   5.173   4.670  1.00  8.85           C  
+ATOM    744  CG1 VAL C  41       4.368   4.397   5.062  1.00  8.85           C  
+ATOM    745  CG2 VAL C  41       6.264   4.512   3.450  1.00  9.44           C  
+ATOM    746  N   ALA C  42       5.091   7.633   6.602  1.00 10.14           N  
+ATOM    747  CA  ALA C  42       4.412   8.161   7.792  1.00 10.96           C  
+ATOM    748  C   ALA C  42       3.652   9.457   7.514  1.00 11.19           C  
+ATOM    749  O   ALA C  42       2.543   9.671   8.025  1.00 12.54           O  
+ATOM    750  CB  ALA C  42       5.420   8.375   8.925  1.00  9.96           C  
+ATOM    751  N   ARG C  43       4.250  10.330   6.715  1.00 11.52           N  
+ATOM    752  CA  ARG C  43       3.610  11.592   6.367  1.00 11.02           C  
+ATOM    753  C   ARG C  43       2.358  11.292   5.542  1.00 11.29           C  
+ATOM    754  O   ARG C  43       1.308  11.923   5.724  1.00 11.57           O  
+ATOM    755  CB  ARG C  43       4.588  12.470   5.579  1.00 11.64           C  
+ATOM    756  CG  ARG C  43       5.741  13.009   6.429  1.00 12.39           C  
+ATOM    757  CD  ARG C  43       6.493  14.145   5.737  1.00 13.37           C  
+ATOM    758  NE  ARG C  43       7.182  13.703   4.522  1.00 14.66           N  
+ATOM    759  CZ  ARG C  43       8.445  13.297   4.482  1.00 14.57           C  
+ATOM    760  NH1 ARG C  43       9.166  13.273   5.596  1.00 16.54           N  
+ATOM    761  NH2 ARG C  43       8.987  12.918   3.334  1.00 13.51           N  
+ATOM    762  N   LEU C  44       2.468  10.309   4.653  1.00 11.55           N  
+ATOM    763  CA  LEU C  44       1.354   9.894   3.790  1.00 12.34           C  
+ATOM    764  C   LEU C  44       0.209   9.334   4.630  1.00 12.24           C  
+ATOM    765  O   LEU C  44      -0.964   9.530   4.322  1.00 11.45           O  
+ATOM    766  CB  LEU C  44       1.834   8.816   2.805  1.00 13.26           C  
+ATOM    767  CG  LEU C  44       1.091   8.643   1.479  1.00 12.89           C  
+ATOM    768  CD1 LEU C  44       1.066   9.968   0.731  1.00 13.22           C  
+ATOM    769  CD2 LEU C  44       1.781   7.573   0.654  1.00 12.61           C  
+ATOM    770  N   TRP C  45       0.569   8.623   5.692  1.00 11.97           N  
+ATOM    771  CA  TRP C  45      -0.403   8.025   6.606  1.00 12.60           C  
+ATOM    772  C   TRP C  45      -1.100   9.140   7.400  1.00 12.86           C  
+ATOM    773  O   TRP C  45      -2.317   9.114   7.613  1.00 12.48           O  
+ATOM    774  CB  TRP C  45       0.335   7.033   7.532  1.00 11.92           C  
+ATOM    775  CG  TRP C  45      -0.471   6.460   8.657  1.00 11.84           C  
+ATOM    776  CD1 TRP C  45      -0.141   6.477   9.990  1.00 12.10           C  
+ATOM    777  CD2 TRP C  45      -1.732   5.777   8.562  1.00 12.01           C  
+ATOM    778  NE1 TRP C  45      -1.120   5.851  10.724  1.00 11.63           N  
+ATOM    779  CE2 TRP C  45      -2.108   5.411   9.878  1.00 11.89           C  
+ATOM    780  CE3 TRP C  45      -2.582   5.439   7.495  1.00 11.55           C  
+ATOM    781  CZ2 TRP C  45      -3.302   4.720  10.156  1.00 12.16           C  
+ATOM    782  CZ3 TRP C  45      -3.771   4.753   7.772  1.00 12.28           C  
+ATOM    783  CH2 TRP C  45      -4.116   4.402   9.095  1.00 12.27           C  
+ATOM    784  N   GLY C  46      -0.324  10.133   7.818  1.00 13.12           N  
+ATOM    785  CA  GLY C  46      -0.893  11.245   8.559  1.00 13.54           C  
+ATOM    786  C   GLY C  46      -1.851  12.069   7.706  1.00 13.89           C  
+ATOM    787  O   GLY C  46      -2.833  12.613   8.213  1.00 12.56           O  
+ATOM    788  N   ILE C  47      -1.563  12.179   6.411  1.00 13.51           N  
+ATOM    789  CA  ILE C  47      -2.429  12.931   5.512  1.00 13.56           C  
+ATOM    790  C   ILE C  47      -3.747  12.161   5.392  1.00 14.81           C  
+ATOM    791  O   ILE C  47      -4.834  12.741   5.446  1.00 15.06           O  
+ATOM    792  CB  ILE C  47      -1.769  13.100   4.114  1.00 12.81           C  
+ATOM    793  CG1 ILE C  47      -0.720  14.219   4.176  1.00 13.13           C  
+ATOM    794  CG2 ILE C  47      -2.832  13.422   3.061  1.00 12.85           C  
+ATOM    795  CD1 ILE C  47       0.226  14.285   2.994  1.00 13.51           C  
+ATOM    796  N   ARG C  48      -3.642  10.844   5.257  1.00 15.43           N  
+ATOM    797  CA  ARG C  48      -4.813   9.987   5.133  1.00 18.30           C  
+ATOM    798  C   ARG C  48      -5.712  10.021   6.381  1.00 18.37           C  
+ATOM    799  O   ARG C  48      -6.934  10.081   6.273  1.00 18.65           O  
+ATOM    800  CB  ARG C  48      -4.360   8.550   4.860  1.00 21.41           C  
+ATOM    801  CG  ARG C  48      -5.471   7.608   4.429  1.00 27.65           C  
+ATOM    802  CD  ARG C  48      -5.912   7.888   3.002  1.00 31.11           C  
+ATOM    803  NE  ARG C  48      -4.808   8.392   2.188  1.00 35.46           N  
+ATOM    804  CZ  ARG C  48      -4.819   8.441   0.859  1.00 37.45           C  
+ATOM    805  NH1 ARG C  48      -5.879   8.013   0.175  1.00 38.27           N  
+ATOM    806  NH2 ARG C  48      -3.762   8.915   0.211  1.00 37.35           N  
+ATOM    807  N   LYS C  49      -5.100   9.988   7.562  1.00 18.38           N  
+ATOM    808  CA  LYS C  49      -5.845   9.991   8.817  1.00 17.99           C  
+ATOM    809  C   LYS C  49      -6.034  11.386   9.389  1.00 18.18           C  
+ATOM    810  O   LYS C  49      -6.663  11.553  10.427  1.00 17.33           O  
+ATOM    811  CB  LYS C  49      -5.133   9.119   9.850  1.00 17.43           C  
+ATOM    812  CG  LYS C  49      -5.217   7.638   9.557  1.00 18.46           C  
+ATOM    813  CD  LYS C  49      -6.452   7.016  10.194  1.00 20.06           C  
+ATOM    814  CE  LYS C  49      -6.093   6.206  11.442  1.00 21.46           C  
+ATOM    815  NZ  LYS C  49      -6.068   7.033  12.679  1.00 22.33           N  
+ATOM    816  N   ASN C  50      -5.481  12.387   8.716  1.00 18.66           N  
+ATOM    817  CA  ASN C  50      -5.598  13.761   9.178  1.00 19.33           C  
+ATOM    818  C   ASN C  50      -4.805  14.041  10.468  1.00 19.35           C  
+ATOM    819  O   ASN C  50      -5.278  14.755  11.353  1.00 18.17           O  
+ATOM    820  CB  ASN C  50      -7.074  14.102   9.389  1.00 20.79           C  
+ATOM    821  CG  ASN C  50      -7.452  15.428   8.788  1.00 22.56           C  
+ATOM    822  OD1 ASN C  50      -7.278  16.479   9.416  1.00 23.99           O  
+ATOM    823  ND2 ASN C  50      -7.967  15.397   7.558  1.00 22.79           N  
+ATOM    824  N   LYS C  51      -3.605  13.471  10.567  1.00 18.39           N  
+ATOM    825  CA  LYS C  51      -2.727  13.671  11.730  1.00 18.54           C  
+ATOM    826  C   LYS C  51      -1.411  14.280  11.218  1.00 17.93           C  
+ATOM    827  O   LYS C  51      -0.425  13.570  11.007  1.00 18.14           O  
+ATOM    828  CB  LYS C  51      -2.447  12.331  12.428  1.00 17.54           C  
+ATOM    829  CG  LYS C  51      -3.692  11.586  12.887  1.00 18.26           C  
+ATOM    830  CD  LYS C  51      -4.284  12.205  14.155  1.00 19.94           C  
+ATOM    831  CE  LYS C  51      -5.620  11.551  14.522  1.00 20.86           C  
+ATOM    832  NZ  LYS C  51      -6.372  12.356  15.535  1.00 22.14           N  
+ATOM    833  N   PRO C  52      -1.381  15.610  11.033  1.00 17.51           N  
+ATOM    834  CA  PRO C  52      -0.212  16.345  10.537  1.00 17.45           C  
+ATOM    835  C   PRO C  52       1.104  16.112  11.244  1.00 16.74           C  
+ATOM    836  O   PRO C  52       2.155  16.373  10.672  1.00 16.69           O  
+ATOM    837  CB  PRO C  52      -0.638  17.811  10.610  1.00 17.13           C  
+ATOM    838  CG  PRO C  52      -1.811  17.830  11.517  1.00 17.91           C  
+ATOM    839  CD  PRO C  52      -2.498  16.521  11.330  1.00 18.33           C  
+ATOM    840  N   ASN C  53       1.060  15.627  12.479  1.00 16.40           N  
+ATOM    841  CA  ASN C  53       2.297  15.396  13.219  1.00 15.45           C  
+ATOM    842  C   ASN C  53       2.729  13.937  13.211  1.00 14.41           C  
+ATOM    843  O   ASN C  53       3.606  13.539  13.977  1.00 13.44           O  
+ATOM    844  CB  ASN C  53       2.148  15.881  14.658  1.00 16.44           C  
+ATOM    845  CG  ASN C  53       1.656  17.314  14.738  1.00 18.48           C  
+ATOM    846  OD1 ASN C  53       0.675  17.610  15.423  1.00 21.02           O  
+ATOM    847  ND2 ASN C  53       2.334  18.210  14.037  1.00 17.02           N  
+ATOM    848  N   MET C  54       2.114  13.144  12.334  1.00 13.34           N  
+ATOM    849  CA  MET C  54       2.438  11.727  12.221  1.00 12.77           C  
+ATOM    850  C   MET C  54       3.869  11.546  11.720  1.00 12.48           C  
+ATOM    851  O   MET C  54       4.325  12.263  10.824  1.00 12.31           O  
+ATOM    852  CB  MET C  54       1.456  11.035  11.254  1.00 12.86           C  
+ATOM    853  CG  MET C  54       1.642   9.522  11.100  1.00  9.65           C  
+ATOM    854  SD  MET C  54       1.898   8.592  12.638  1.00 12.30           S  
+ATOM    855  CE  MET C  54       0.306   8.848  13.488  1.00 10.42           C  
+ATOM    856  N   ASN C  55       4.588  10.605  12.317  1.00 11.48           N  
+ATOM    857  CA  ASN C  55       5.947  10.331  11.880  1.00 11.27           C  
+ATOM    858  C   ASN C  55       6.185   8.840  12.036  1.00 11.24           C  
+ATOM    859  O   ASN C  55       5.294   8.108  12.496  1.00 10.72           O  
+ATOM    860  CB  ASN C  55       6.976  11.154  12.676  1.00 10.80           C  
+ATOM    861  CG  ASN C  55       6.892  10.919  14.163  1.00 10.59           C  
+ATOM    862  OD1 ASN C  55       6.516   9.843  14.604  1.00 11.77           O  
+ATOM    863  ND2 ASN C  55       7.247  11.931  14.948  1.00  9.97           N  
+ATOM    864  N   TYR C  56       7.368   8.378  11.644  1.00  9.65           N  
+ATOM    865  CA  TYR C  56       7.657   6.957  11.734  1.00  9.41           C  
+ATOM    866  C   TYR C  56       7.709   6.457  13.178  1.00  9.09           C  
+ATOM    867  O   TYR C  56       7.413   5.294  13.448  1.00  9.69           O  
+ATOM    868  CB  TYR C  56       8.969   6.632  11.018  1.00  8.18           C  
+ATOM    869  CG  TYR C  56       9.331   5.170  11.078  1.00  7.50           C  
+ATOM    870  CD1 TYR C  56       8.417   4.190  10.672  1.00  5.68           C  
+ATOM    871  CD2 TYR C  56      10.572   4.758  11.571  1.00  5.84           C  
+ATOM    872  CE1 TYR C  56       8.731   2.841  10.759  1.00  6.06           C  
+ATOM    873  CE2 TYR C  56      10.893   3.408  11.663  1.00  5.84           C  
+ATOM    874  CZ  TYR C  56       9.968   2.457  11.258  1.00  5.03           C  
+ATOM    875  OH  TYR C  56      10.265   1.127  11.371  1.00  4.77           O  
+ATOM    876  N   ASP C  57       8.089   7.333  14.100  1.00  9.57           N  
+ATOM    877  CA  ASP C  57       8.156   6.952  15.508  1.00 10.25           C  
+ATOM    878  C   ASP C  57       6.808   6.390  15.949  1.00 10.20           C  
+ATOM    879  O   ASP C  57       6.719   5.256  16.418  1.00 10.44           O  
+ATOM    880  CB  ASP C  57       8.504   8.171  16.355  1.00 11.38           C  
+ATOM    881  CG  ASP C  57       8.725   7.828  17.820  1.00 13.26           C  
+ATOM    882  OD1 ASP C  57       8.722   6.638  18.183  1.00 15.46           O  
+ATOM    883  OD2 ASP C  57       8.907   8.765  18.611  1.00 15.16           O  
+ATOM    884  N   LYS C  58       5.761   7.191  15.778  1.00 10.70           N  
+ATOM    885  CA  LYS C  58       4.413   6.796  16.162  1.00 10.53           C  
+ATOM    886  C   LYS C  58       3.806   5.728  15.251  1.00  9.80           C  
+ATOM    887  O   LYS C  58       3.042   4.896  15.714  1.00  9.96           O  
+ATOM    888  CB  LYS C  58       3.514   8.034  16.207  1.00 10.90           C  
+ATOM    889  CG  LYS C  58       3.918   9.026  17.293  1.00 10.57           C  
+ATOM    890  CD  LYS C  58       3.076  10.289  17.238  1.00 10.36           C  
+ATOM    891  CE  LYS C  58       3.729  11.368  16.388  1.00 10.57           C  
+ATOM    892  NZ  LYS C  58       2.956  12.649  16.380  1.00  8.98           N  
+ATOM    893  N   LEU C  59       4.131   5.745  13.959  1.00  9.78           N  
+ATOM    894  CA  LEU C  59       3.596   4.726  13.054  1.00  8.53           C  
+ATOM    895  C   LEU C  59       4.143   3.365  13.478  1.00  8.51           C  
+ATOM    896  O   LEU C  59       3.419   2.372  13.518  1.00  7.31           O  
+ATOM    897  CB  LEU C  59       3.989   5.024  11.589  1.00  8.50           C  
+ATOM    898  CG  LEU C  59       3.374   4.143  10.483  1.00  7.12           C  
+ATOM    899  CD1 LEU C  59       3.338   4.937   9.170  1.00  8.48           C  
+ATOM    900  CD2 LEU C  59       4.164   2.862  10.286  1.00  5.61           C  
+ATOM    901  N   SER C  60       5.430   3.329  13.806  1.00  8.84           N  
+ATOM    902  CA  SER C  60       6.062   2.097  14.238  1.00  9.16           C  
+ATOM    903  C   SER C  60       5.406   1.599  15.537  1.00  8.58           C  
+ATOM    904  O   SER C  60       5.298   0.392  15.756  1.00  8.59           O  
+ATOM    905  CB  SER C  60       7.575   2.315  14.428  1.00  9.28           C  
+ATOM    906  OG  SER C  60       7.880   3.120  15.566  1.00  9.83           O  
+ATOM    907  N   ARG C  61       4.961   2.509  16.402  1.00  8.63           N  
+ATOM    908  CA  ARG C  61       4.311   2.062  17.636  1.00  8.08           C  
+ATOM    909  C   ARG C  61       3.026   1.323  17.282  1.00  8.43           C  
+ATOM    910  O   ARG C  61       2.678   0.328  17.920  1.00  8.82           O  
+ATOM    911  CB  ARG C  61       3.984   3.231  18.561  1.00  9.18           C  
+ATOM    912  CG  ARG C  61       3.413   2.781  19.914  1.00  8.79           C  
+ATOM    913  CD  ARG C  61       4.399   1.874  20.656  1.00  9.92           C  
+ATOM    914  NE  ARG C  61       3.873   1.201  21.853  1.00  8.43           N  
+ATOM    915  CZ  ARG C  61       3.348  -0.022  21.863  1.00  9.08           C  
+ATOM    916  NH1 ARG C  61       3.260  -0.729  20.741  1.00  8.52           N  
+ATOM    917  NH2 ARG C  61       2.962  -0.569  23.010  1.00  7.55           N  
+ATOM    918  N   ALA C  62       2.321   1.818  16.262  1.00  7.20           N  
+ATOM    919  CA  ALA C  62       1.086   1.187  15.794  1.00  7.19           C  
+ATOM    920  C   ALA C  62       1.404  -0.187  15.209  1.00  7.46           C  
+ATOM    921  O   ALA C  62       0.632  -1.138  15.361  1.00  6.68           O  
+ATOM    922  CB  ALA C  62       0.415   2.069  14.743  1.00  7.48           C  
+ATOM    923  N   LEU C  63       2.544  -0.301  14.529  1.00  7.60           N  
+ATOM    924  CA  LEU C  63       2.934  -1.583  13.961  1.00  6.61           C  
+ATOM    925  C   LEU C  63       3.232  -2.545  15.106  1.00  7.16           C  
+ATOM    926  O   LEU C  63       2.899  -3.727  15.039  1.00  7.33           O  
+ATOM    927  CB  LEU C  63       4.175  -1.426  13.076  1.00  7.16           C  
+ATOM    928  CG  LEU C  63       3.931  -0.766  11.711  1.00  7.30           C  
+ATOM    929  CD1 LEU C  63       5.260  -0.639  10.951  1.00  8.28           C  
+ATOM    930  CD2 LEU C  63       2.904  -1.576  10.923  1.00  6.98           C  
+ATOM    931  N   ARG C  64       3.853  -2.034  16.162  1.00  7.76           N  
+ATOM    932  CA  ARG C  64       4.197  -2.873  17.304  1.00  9.75           C  
+ATOM    933  C   ARG C  64       2.961  -3.443  17.983  1.00 10.09           C  
+ATOM    934  O   ARG C  64       3.001  -4.522  18.564  1.00 11.06           O  
+ATOM    935  CB  ARG C  64       5.049  -2.078  18.291  1.00 11.13           C  
+ATOM    936  CG  ARG C  64       6.497  -1.940  17.821  1.00 13.94           C  
+ATOM    937  CD  ARG C  64       7.447  -1.607  18.953  1.00 13.57           C  
+ATOM    938  NE  ARG C  64       7.285  -0.230  19.398  1.00 16.02           N  
+ATOM    939  CZ  ARG C  64       7.698   0.837  18.718  1.00 14.50           C  
+ATOM    940  NH1 ARG C  64       8.310   0.700  17.548  1.00 15.49           N  
+ATOM    941  NH2 ARG C  64       7.514   2.051  19.219  1.00 17.42           N  
+ATOM    942  N   TYR C  65       1.852  -2.726  17.888  1.00 10.27           N  
+ATOM    943  CA  TYR C  65       0.602  -3.202  18.471  1.00 10.38           C  
+ATOM    944  C   TYR C  65       0.064  -4.378  17.654  1.00 10.36           C  
+ATOM    945  O   TYR C  65      -0.732  -5.179  18.144  1.00 11.51           O  
+ATOM    946  CB  TYR C  65      -0.419  -2.064  18.515  1.00  8.91           C  
+ATOM    947  CG  TYR C  65      -0.399  -1.299  19.817  1.00  7.96           C  
+ATOM    948  CD1 TYR C  65      -0.455  -1.972  21.044  1.00  8.67           C  
+ATOM    949  CD2 TYR C  65      -0.301   0.086  19.826  1.00  7.43           C  
+ATOM    950  CE1 TYR C  65      -0.407  -1.271  22.260  1.00  8.27           C  
+ATOM    951  CE2 TYR C  65      -0.255   0.796  21.020  1.00  8.64           C  
+ATOM    952  CZ  TYR C  65      -0.307   0.113  22.240  1.00  7.47           C  
+ATOM    953  OH  TYR C  65      -0.254   0.825  23.418  1.00  7.88           O  
+ATOM    954  N   TYR C  66       0.508  -4.485  16.405  1.00  9.19           N  
+ATOM    955  CA  TYR C  66       0.065  -5.565  15.534  1.00  8.52           C  
+ATOM    956  C   TYR C  66       0.768  -6.874  15.891  1.00  8.33           C  
+ATOM    957  O   TYR C  66       0.320  -7.946  15.492  1.00  7.53           O  
+ATOM    958  CB  TYR C  66       0.346  -5.219  14.059  1.00  7.48           C  
+ATOM    959  CG  TYR C  66      -0.596  -4.213  13.406  1.00  7.02           C  
+ATOM    960  CD1 TYR C  66      -1.929  -4.090  13.806  1.00  8.57           C  
+ATOM    961  CD2 TYR C  66      -0.153  -3.416  12.359  1.00  6.76           C  
+ATOM    962  CE1 TYR C  66      -2.792  -3.197  13.168  1.00  7.43           C  
+ATOM    963  CE2 TYR C  66      -0.999  -2.523  11.715  1.00  8.37           C  
+ATOM    964  CZ  TYR C  66      -2.318  -2.417  12.119  1.00  7.99           C  
+ATOM    965  OH  TYR C  66      -3.148  -1.550  11.441  1.00  7.10           O  
+ATOM    966  N   TYR C  67       1.871  -6.792  16.632  1.00  8.83           N  
+ATOM    967  CA  TYR C  67       2.606  -7.999  17.015  1.00 10.40           C  
+ATOM    968  C   TYR C  67       1.705  -8.898  17.852  1.00 11.72           C  
+ATOM    969  O   TYR C  67       1.666 -10.115  17.673  1.00 11.71           O  
+ATOM    970  CB  TYR C  67       3.852  -7.660  17.851  1.00  9.37           C  
+ATOM    971  CG  TYR C  67       4.928  -6.836  17.162  1.00 10.05           C  
+ATOM    972  CD1 TYR C  67       4.873  -6.555  15.794  1.00  9.16           C  
+ATOM    973  CD2 TYR C  67       5.986  -6.308  17.896  1.00  8.84           C  
+ATOM    974  CE1 TYR C  67       5.843  -5.765  15.185  1.00  9.08           C  
+ATOM    975  CE2 TYR C  67       6.966  -5.514  17.293  1.00  8.30           C  
+ATOM    976  CZ  TYR C  67       6.888  -5.245  15.942  1.00  9.60           C  
+ATOM    977  OH  TYR C  67       7.853  -4.458  15.358  1.00  9.17           O  
+ATOM    978  N   VAL C  68       1.000  -8.272  18.785  1.00 13.15           N  
+ATOM    979  CA  VAL C  68       0.084  -8.964  19.684  1.00 14.69           C  
+ATOM    980  C   VAL C  68      -1.109  -9.530  18.910  1.00 14.89           C  
+ATOM    981  O   VAL C  68      -1.571 -10.649  19.168  1.00 15.85           O  
+ATOM    982  CB  VAL C  68      -0.453  -7.989  20.750  1.00 15.58           C  
+ATOM    983  CG1 VAL C  68      -1.250  -8.751  21.789  1.00 17.01           C  
+ATOM    984  CG2 VAL C  68       0.703  -7.236  21.400  1.00 15.02           C  
+ATOM    985  N   LYS C  69      -1.598  -8.736  17.962  1.00 15.36           N  
+ATOM    986  CA  LYS C  69      -2.733  -9.109  17.137  1.00 14.63           C  
+ATOM    987  C   LYS C  69      -2.364 -10.141  16.087  1.00 14.51           C  
+ATOM    988  O   LYS C  69      -3.232 -10.741  15.458  1.00 14.53           O  
+ATOM    989  CB  LYS C  69      -3.303  -7.861  16.469  1.00 15.89           C  
+ATOM    990  CG  LYS C  69      -4.383  -7.180  17.295  1.00 17.72           C  
+ATOM    991  CD  LYS C  69      -4.267  -5.679  17.232  1.00 19.32           C  
+ATOM    992  CE  LYS C  69      -5.512  -5.060  16.616  1.00 21.50           C  
+ATOM    993  NZ  LYS C  69      -5.363  -3.586  16.437  1.00 22.25           N  
+ATOM    994  N   ASN C  70      -1.071 -10.350  15.899  1.00 14.12           N  
+ATOM    995  CA  ASN C  70      -0.596 -11.309  14.916  1.00 15.18           C  
+ATOM    996  C   ASN C  70      -0.943 -10.912  13.490  1.00 14.76           C  
+ATOM    997  O   ASN C  70      -1.236 -11.763  12.661  1.00 14.35           O  
+ATOM    998  CB  ASN C  70      -1.167 -12.691  15.206  1.00 17.62           C  
+ATOM    999  CG  ASN C  70      -0.164 -13.582  15.876  1.00 21.38           C  
+ATOM   1000  OD1 ASN C  70       0.662 -14.215  15.208  1.00 24.45           O  
+ATOM   1001  ND2 ASN C  70      -0.205 -13.628  17.213  1.00 21.93           N  
+ATOM   1002  N   ILE C  71      -0.916  -9.615  13.215  1.00 15.04           N  
+ATOM   1003  CA  ILE C  71      -1.207  -9.113  11.879  1.00 14.46           C  
+ATOM   1004  C   ILE C  71       0.127  -8.886  11.176  1.00 14.30           C  
+ATOM   1005  O   ILE C  71       0.306  -9.250  10.014  1.00 14.38           O  
+ATOM   1006  CB  ILE C  71      -1.983  -7.774  11.939  1.00 14.25           C  
+ATOM   1007  CG1 ILE C  71      -3.458  -8.040  12.256  1.00 13.44           C  
+ATOM   1008  CG2 ILE C  71      -1.847  -7.023  10.608  1.00 13.90           C  
+ATOM   1009  CD1 ILE C  71      -4.281  -6.775  12.394  1.00 13.78           C  
+ATOM   1010  N   ILE C  72       1.058  -8.290  11.912  1.00 13.62           N  
+ATOM   1011  CA  ILE C  72       2.390  -7.989  11.409  1.00 13.17           C  
+ATOM   1012  C   ILE C  72       3.421  -8.258  12.508  1.00 13.95           C  
+ATOM   1013  O   ILE C  72       3.170  -8.020  13.692  1.00 13.85           O  
+ATOM   1014  CB  ILE C  72       2.511  -6.490  10.968  1.00 11.77           C  
+ATOM   1015  CG1 ILE C  72       1.923  -6.295   9.572  1.00 11.57           C  
+ATOM   1016  CG2 ILE C  72       3.973  -6.060  10.918  1.00 11.60           C  
+ATOM   1017  CD1 ILE C  72       1.499  -4.868   9.273  1.00  7.49           C  
+ATOM   1018  N   LYS C  73       4.574  -8.777  12.103  1.00 13.63           N  
+ATOM   1019  CA  LYS C  73       5.657  -9.043  13.026  1.00 14.30           C  
+ATOM   1020  C   LYS C  73       6.886  -8.323  12.487  1.00 14.22           C  
+ATOM   1021  O   LYS C  73       6.925  -7.929  11.320  1.00 13.58           O  
+ATOM   1022  CB  LYS C  73       5.907 -10.554  13.157  1.00 14.69           C  
+ATOM   1023  CG  LYS C  73       6.799 -11.161  12.100  1.00 18.04           C  
+ATOM   1024  CD  LYS C  73       6.543 -12.654  11.957  1.00 19.63           C  
+ATOM   1025  CE  LYS C  73       7.783 -13.484  12.288  1.00 21.78           C  
+ATOM   1026  NZ  LYS C  73       9.058 -12.710  12.167  1.00 22.69           N  
+ATOM   1027  N   LYS C  74       7.876  -8.120  13.343  1.00 14.42           N  
+ATOM   1028  CA  LYS C  74       9.099  -7.454  12.934  1.00 14.67           C  
+ATOM   1029  C   LYS C  74      10.081  -8.490  12.388  1.00 15.80           C  
+ATOM   1030  O   LYS C  74      10.115  -9.625  12.870  1.00 15.92           O  
+ATOM   1031  CB  LYS C  74       9.717  -6.723  14.138  1.00 12.80           C  
+ATOM   1032  CG  LYS C  74      10.999  -5.970  13.837  1.00 11.08           C  
+ATOM   1033  CD  LYS C  74      10.708  -4.644  13.174  1.00 10.42           C  
+ATOM   1034  CE  LYS C  74      11.992  -3.892  12.857  1.00  9.87           C  
+ATOM   1035  NZ  LYS C  74      12.762  -4.522  11.754  1.00 11.20           N  
+ATOM   1036  N   VAL C  75      10.838  -8.128  11.350  1.00 16.68           N  
+ATOM   1037  CA  VAL C  75      11.859  -9.038  10.829  1.00 17.58           C  
+ATOM   1038  C   VAL C  75      13.081  -8.613  11.652  1.00 18.13           C  
+ATOM   1039  O   VAL C  75      13.637  -7.535  11.449  1.00 17.55           O  
+ATOM   1040  CB  VAL C  75      12.115  -8.835   9.311  1.00 17.50           C  
+ATOM   1041  CG1 VAL C  75      13.440  -9.470   8.913  1.00 16.62           C  
+ATOM   1042  CG2 VAL C  75      10.989  -9.468   8.508  1.00 16.79           C  
+ATOM   1043  N   ASN C  76      13.467  -9.452  12.608  1.00 19.79           N  
+ATOM   1044  CA  ASN C  76      14.576  -9.143  13.503  1.00 21.98           C  
+ATOM   1045  C   ASN C  76      15.916  -8.827  12.830  1.00 22.65           C  
+ATOM   1046  O   ASN C  76      16.351  -9.525  11.908  1.00 23.63           O  
+ATOM   1047  CB  ASN C  76      14.762 -10.287  14.515  1.00 23.73           C  
+ATOM   1048  CG  ASN C  76      13.601 -10.394  15.524  1.00 25.34           C  
+ATOM   1049  OD1 ASN C  76      12.887  -9.420  15.791  1.00 25.89           O  
+ATOM   1050  ND2 ASN C  76      13.423 -11.583  16.088  1.00 25.50           N  
+ATOM   1051  N   GLY C  77      16.560  -7.762  13.306  1.00 23.02           N  
+ATOM   1052  CA  GLY C  77      17.860  -7.362  12.789  1.00 23.18           C  
+ATOM   1053  C   GLY C  77      17.910  -6.851  11.361  1.00 22.80           C  
+ATOM   1054  O   GLY C  77      18.944  -6.946  10.703  1.00 23.63           O  
+ATOM   1055  N   GLN C  78      16.796  -6.310  10.882  1.00 22.12           N  
+ATOM   1056  CA  GLN C  78      16.718  -5.771   9.526  1.00 21.12           C  
+ATOM   1057  C   GLN C  78      15.926  -4.480   9.563  1.00 19.71           C  
+ATOM   1058  O   GLN C  78      14.704  -4.496   9.476  1.00 19.91           O  
+ATOM   1059  CB  GLN C  78      16.040  -6.773   8.594  1.00 20.85           C  
+ATOM   1060  CG  GLN C  78      16.786  -8.088   8.496  1.00 23.29           C  
+ATOM   1061  CD  GLN C  78      16.579  -8.786   7.179  1.00 23.32           C  
+ATOM   1062  OE1 GLN C  78      16.364  -9.998   7.137  1.00 24.32           O  
+ATOM   1063  NE2 GLN C  78      16.637  -8.028   6.088  1.00 24.06           N  
+ATOM   1064  N   LYS C  79      16.639  -3.367   9.695  1.00 19.31           N  
+ATOM   1065  CA  LYS C  79      16.029  -2.045   9.769  1.00 19.08           C  
+ATOM   1066  C   LYS C  79      14.916  -1.814   8.754  1.00 17.55           C  
+ATOM   1067  O   LYS C  79      15.066  -2.109   7.569  1.00 16.61           O  
+ATOM   1068  CB  LYS C  79      17.098  -0.956   9.608  1.00 21.75           C  
+ATOM   1069  CG  LYS C  79      17.665  -0.435  10.923  1.00 25.31           C  
+ATOM   1070  CD  LYS C  79      19.090   0.084  10.738  1.00 27.64           C  
+ATOM   1071  CE  LYS C  79      19.213   1.549  11.143  1.00 29.74           C  
+ATOM   1072  NZ  LYS C  79      20.550   2.135  10.805  1.00 30.60           N  
+ATOM   1073  N   PHE C  80      13.795  -1.295   9.254  1.00 16.54           N  
+ATOM   1074  CA  PHE C  80      12.615  -0.972   8.454  1.00 14.66           C  
+ATOM   1075  C   PHE C  80      11.898  -2.143   7.774  1.00 13.79           C  
+ATOM   1076  O   PHE C  80      10.962  -1.936   6.998  1.00 13.22           O  
+ATOM   1077  CB  PHE C  80      13.002   0.096   7.425  1.00 13.47           C  
+ATOM   1078  CG  PHE C  80      13.634   1.313   8.038  1.00 12.85           C  
+ATOM   1079  CD1 PHE C  80      12.906   2.129   8.898  1.00 12.11           C  
+ATOM   1080  CD2 PHE C  80      14.958   1.639   7.770  1.00 13.01           C  
+ATOM   1081  CE1 PHE C  80      13.480   3.248   9.480  1.00 11.95           C  
+ATOM   1082  CE2 PHE C  80      15.550   2.764   8.351  1.00 13.46           C  
+ATOM   1083  CZ  PHE C  80      14.806   3.570   9.209  1.00 12.93           C  
+ATOM   1084  N   VAL C  81      12.325  -3.367   8.079  1.00 12.95           N  
+ATOM   1085  CA  VAL C  81      11.723  -4.553   7.489  1.00 12.76           C  
+ATOM   1086  C   VAL C  81      10.730  -5.217   8.435  1.00 12.86           C  
+ATOM   1087  O   VAL C  81      11.028  -5.455   9.611  1.00 12.04           O  
+ATOM   1088  CB  VAL C  81      12.786  -5.589   7.095  1.00 13.13           C  
+ATOM   1089  CG1 VAL C  81      12.113  -6.789   6.438  1.00 12.76           C  
+ATOM   1090  CG2 VAL C  81      13.815  -4.954   6.150  1.00 12.86           C  
+ATOM   1091  N   TYR C  82       9.552  -5.515   7.899  1.00 12.32           N  
+ATOM   1092  CA  TYR C  82       8.475  -6.140   8.649  1.00 11.73           C  
+ATOM   1093  C   TYR C  82       7.896  -7.264   7.810  1.00 12.75           C  
+ATOM   1094  O   TYR C  82       8.253  -7.438   6.647  1.00 11.53           O  
+ATOM   1095  CB  TYR C  82       7.366  -5.126   8.944  1.00 10.72           C  
+ATOM   1096  CG  TYR C  82       7.735  -4.052   9.941  1.00 10.37           C  
+ATOM   1097  CD1 TYR C  82       8.380  -2.886   9.530  1.00  8.83           C  
+ATOM   1098  CD2 TYR C  82       7.423  -4.198  11.306  1.00  9.50           C  
+ATOM   1099  CE1 TYR C  82       8.706  -1.888  10.445  1.00 10.03           C  
+ATOM   1100  CE2 TYR C  82       7.744  -3.202  12.231  1.00  8.39           C  
+ATOM   1101  CZ  TYR C  82       8.382  -2.053  11.798  1.00  9.03           C  
+ATOM   1102  OH  TYR C  82       8.690  -1.054  12.698  1.00  7.61           O  
+ATOM   1103  N   LYS C  83       6.977  -8.016   8.397  1.00 12.52           N  
+ATOM   1104  CA  LYS C  83       6.372  -9.119   7.685  1.00 13.39           C  
+ATOM   1105  C   LYS C  83       4.920  -9.292   8.044  1.00 14.28           C  
+ATOM   1106  O   LYS C  83       4.553  -9.245   9.214  1.00 14.32           O  
+ATOM   1107  CB  LYS C  83       7.110 -10.419   7.991  1.00 12.92           C  
+ATOM   1108  CG  LYS C  83       6.695 -11.549   7.081  1.00 13.81           C  
+ATOM   1109  CD  LYS C  83       7.118 -12.889   7.619  1.00 14.96           C  
+ATOM   1110  CE  LYS C  83       6.438 -14.009   6.856  1.00 15.12           C  
+ATOM   1111  NZ  LYS C  83       7.292 -15.222   6.868  1.00 17.44           N  
+ATOM   1112  N   PHE C  84       4.089  -9.482   7.030  1.00 14.91           N  
+ATOM   1113  CA  PHE C  84       2.678  -9.712   7.264  1.00 15.58           C  
+ATOM   1114  C   PHE C  84       2.607 -11.164   7.727  1.00 16.64           C  
+ATOM   1115  O   PHE C  84       3.049 -12.067   7.017  1.00 16.37           O  
+ATOM   1116  CB  PHE C  84       1.889  -9.516   5.971  1.00 14.77           C  
+ATOM   1117  CG  PHE C  84       1.273  -8.150   5.841  1.00 14.94           C  
+ATOM   1118  CD1 PHE C  84       0.003  -7.896   6.348  1.00 14.24           C  
+ATOM   1119  CD2 PHE C  84       1.971  -7.113   5.231  1.00 14.57           C  
+ATOM   1120  CE1 PHE C  84      -0.561  -6.633   6.255  1.00 14.52           C  
+ATOM   1121  CE2 PHE C  84       1.413  -5.836   5.131  1.00 15.10           C  
+ATOM   1122  CZ  PHE C  84       0.143  -5.596   5.646  1.00 14.93           C  
+ATOM   1123  N   VAL C  85       2.071 -11.388   8.925  1.00 17.82           N  
+ATOM   1124  CA  VAL C  85       1.985 -12.740   9.467  1.00 18.88           C  
+ATOM   1125  C   VAL C  85       1.360 -13.705   8.479  1.00 20.66           C  
+ATOM   1126  O   VAL C  85       1.939 -14.754   8.183  1.00 21.86           O  
+ATOM   1127  CB  VAL C  85       1.193 -12.770  10.792  1.00 17.64           C  
+ATOM   1128  CG1 VAL C  85       0.860 -14.207  11.178  1.00 15.48           C  
+ATOM   1129  CG2 VAL C  85       2.012 -12.108  11.885  1.00 16.17           C  
+ATOM   1130  N   SER C  86       0.183 -13.359   7.967  1.00 21.72           N  
+ATOM   1131  CA  SER C  86      -0.487 -14.222   7.002  1.00 22.54           C  
+ATOM   1132  C   SER C  86      -1.010 -13.449   5.796  1.00 22.73           C  
+ATOM   1133  O   SER C  86      -2.179 -13.051   5.728  1.00 22.37           O  
+ATOM   1134  CB  SER C  86      -1.621 -15.004   7.671  1.00 23.48           C  
+ATOM   1135  OG  SER C  86      -1.194 -16.318   7.995  1.00 24.33           O  
+ATOM   1136  N   TYR C  87      -0.102 -13.221   4.855  1.00 22.08           N  
+ATOM   1137  CA  TYR C  87      -0.418 -12.532   3.617  1.00 22.03           C  
+ATOM   1138  C   TYR C  87      -0.442 -13.663   2.600  1.00 21.40           C  
+ATOM   1139  O   TYR C  87       0.460 -14.490   2.588  1.00 22.45           O  
+ATOM   1140  CB  TYR C  87       0.692 -11.536   3.274  1.00 22.30           C  
+ATOM   1141  CG  TYR C  87       0.540 -10.897   1.918  1.00 22.10           C  
+ATOM   1142  CD1 TYR C  87      -0.411  -9.899   1.702  1.00 23.20           C  
+ATOM   1143  CD2 TYR C  87       1.334 -11.298   0.842  1.00 22.66           C  
+ATOM   1144  CE1 TYR C  87      -0.571  -9.313   0.441  1.00 23.46           C  
+ATOM   1145  CE2 TYR C  87       1.184 -10.719  -0.423  1.00 23.75           C  
+ATOM   1146  CZ  TYR C  87       0.230  -9.729  -0.612  1.00 23.35           C  
+ATOM   1147  OH  TYR C  87       0.085  -9.144  -1.850  1.00 25.66           O  
+ATOM   1148  N   PRO C  88      -1.474 -13.726   1.743  1.00 20.96           N  
+ATOM   1149  CA  PRO C  88      -2.643 -12.851   1.604  1.00 20.08           C  
+ATOM   1150  C   PRO C  88      -3.914 -13.295   2.337  1.00 19.87           C  
+ATOM   1151  O   PRO C  88      -5.005 -12.823   2.027  1.00 20.52           O  
+ATOM   1152  CB  PRO C  88      -2.861 -12.823   0.100  1.00 20.27           C  
+ATOM   1153  CG  PRO C  88      -2.404 -14.204  -0.351  1.00 20.22           C  
+ATOM   1154  CD  PRO C  88      -1.485 -14.777   0.711  1.00 20.61           C  
+ATOM   1155  N   GLU C  89      -3.787 -14.208   3.290  1.00 19.86           N  
+ATOM   1156  CA  GLU C  89      -4.942 -14.690   4.047  1.00 20.05           C  
+ATOM   1157  C   GLU C  89      -5.803 -13.534   4.586  1.00 20.66           C  
+ATOM   1158  O   GLU C  89      -7.038 -13.619   4.636  1.00 19.63           O  
+ATOM   1159  CB  GLU C  89      -4.461 -15.544   5.222  1.00 19.55           C  
+ATOM   1160  CG  GLU C  89      -5.370 -16.698   5.581  1.00 19.44           C  
+ATOM   1161  CD  GLU C  89      -6.016 -17.329   4.372  1.00 19.27           C  
+ATOM   1162  OE1 GLU C  89      -5.384 -18.206   3.738  1.00 18.84           O  
+ATOM   1163  OE2 GLU C  89      -7.161 -16.942   4.062  1.00 19.27           O  
+ATOM   1164  N   ILE C  90      -5.140 -12.452   4.982  1.00 21.14           N  
+ATOM   1165  CA  ILE C  90      -5.826 -11.287   5.531  1.00 22.72           C  
+ATOM   1166  C   ILE C  90      -6.670 -10.532   4.491  1.00 23.33           C  
+ATOM   1167  O   ILE C  90      -7.395  -9.588   4.829  1.00 23.89           O  
+ATOM   1168  CB  ILE C  90      -4.789 -10.321   6.186  1.00 22.93           C  
+ATOM   1169  CG1 ILE C  90      -5.513  -9.233   6.986  1.00 23.11           C  
+ATOM   1170  CG2 ILE C  90      -3.858  -9.732   5.115  1.00 21.50           C  
+ATOM   1171  CD1 ILE C  90      -4.581  -8.428   7.882  1.00 23.60           C  
+ATOM   1172  N   LEU C  91      -6.577 -10.948   3.228  1.00 24.25           N  
+ATOM   1173  CA  LEU C  91      -7.338 -10.295   2.160  1.00 25.74           C  
+ATOM   1174  C   LEU C  91      -8.600 -11.055   1.730  1.00 26.58           C  
+ATOM   1175  O   LEU C  91      -9.434 -10.527   1.002  1.00 26.60           O  
+ATOM   1176  CB  LEU C  91      -6.419 -10.001   0.962  1.00 25.03           C  
+ATOM   1177  CG  LEU C  91      -5.510  -8.784   1.143  1.00 26.09           C  
+ATOM   1178  CD1 LEU C  91      -5.070  -8.271  -0.222  1.00 26.13           C  
+ATOM   1179  CD2 LEU C  91      -6.242  -7.693   1.904  1.00 25.12           C  
+ATOM   1180  N   ASN C  92      -8.733 -12.301   2.167  1.00 28.46           N  
+ATOM   1181  CA  ASN C  92      -9.945 -13.070   1.889  1.00 30.65           C  
+ATOM   1182  C   ASN C  92     -10.546 -13.404   3.247  1.00 33.17           C  
+ATOM   1183  O   ASN C  92     -10.434 -14.541   3.724  1.00 33.49           O  
+ATOM   1184  CB  ASN C  92      -9.672 -14.381   1.159  1.00 30.54           C  
+ATOM   1185  CG  ASN C  92      -8.447 -14.328   0.317  1.00 31.12           C  
+ATOM   1186  OD1 ASN C  92      -8.522 -14.377  -0.909  1.00 30.94           O  
+ATOM   1187  ND2 ASN C  92      -7.290 -14.226   0.967  1.00 31.19           N  
+ATOM   1188  N   MET C  93     -11.152 -12.402   3.878  1.00 34.91           N  
+ATOM   1189  CA  MET C  93     -11.779 -12.611   5.167  1.00 35.90           C  
+ATOM   1190  C   MET C  93     -13.050 -13.403   4.882  1.00 36.50           C  
+ATOM   1191  O   MET C  93     -13.476 -14.188   5.762  1.00 36.90           O  
+ATOM   1192  CB  MET C  93     -12.110 -11.265   5.802  1.00 36.07           C  
+ATOM   1193  CG  MET C  93     -11.129 -10.895   6.912  1.00 37.16           C  
+ATOM   1194  SD  MET C  93     -10.619  -9.145   6.971  1.00 39.69           S  
+ATOM   1195  CE  MET C  93      -9.062  -9.270   7.750  1.00 37.29           C  
+ATOM   1196  OXT MET C  93     -13.574 -13.244   3.754  1.00 36.38           O  
+TER    1197      MET C  93                                                      
+HETATM 1198 ZN    ZN B   2      12.870   8.232  24.146  1.00 26.33          ZN  
+HETATM 1199 ZN    ZN C  94      -8.319 -18.103   2.886  1.00 15.69          ZN  
+HETATM 1200  O   HOH A  19      -3.779   2.060  27.272  1.00  2.00           O  
+HETATM 1201  O   HOH A  20      -4.182   3.536  31.329  1.00 12.57           O  
+HETATM 1202  O   HOH A  21      -2.030   1.708  34.158  1.00 19.76           O  
+HETATM 1203  O   HOH A  23      -7.263   9.583  33.539  1.00 29.52           O  
+HETATM 1204  O   HOH A  24      -7.793   6.387  29.739  1.00 27.14           O  
+HETATM 1205  O   HOH A  25      -9.006   4.494  26.763  1.00 26.07           O  
+HETATM 1206  O   HOH A  26      19.360   7.516  22.897  1.00 19.18           O  
+HETATM 1207  O   HOH A  47      15.527   9.205   8.859  1.00 39.43           O  
+HETATM 1208  O   HOH A  48      14.477   9.809  12.041  1.00 34.73           O  
+HETATM 1209  O   HOH A  50      11.216   5.269  14.800  1.00 30.33           O  
+HETATM 1210  O   HOH A  51      13.068   5.710  16.139  1.00 22.93           O  
+HETATM 1211  O   HOH A  52      12.870   6.418  18.713  1.00 18.61           O  
+HETATM 1212  O   HOH A  53      16.109   7.158  20.592  1.00 34.83           O  
+HETATM 1213  O   HOH A  57       8.365  -8.310  20.088  1.00 15.96           O  
+HETATM 1214  O   HOH A  58       4.189  -5.088  21.008  1.00 17.58           O  
+HETATM 1215  O   HOH A  59       6.180 -10.522  24.664  1.00 28.40           O  
+HETATM 1216  O   HOH A  60      18.129  13.454  14.823  1.00 23.77           O  
+HETATM 1217  O   HOH A  71       9.743   3.882  18.463  1.00  9.48           O  
+HETATM 1218  O   HOH A  72      11.098   1.122  15.107  1.00  7.24           O  
+HETATM 1219  O   HOH A  73       9.096  -0.982  15.460  1.00  4.41           O  
+HETATM 1220  O   HOH A  74       9.513  -7.765  17.970  1.00 15.12           O  
+HETATM 1221  O   HOH A  77      13.154  -6.908  16.674  1.00  8.41           O  
+HETATM 1222  O   HOH A  84      -8.382   8.838  28.652  1.00 28.87           O  
+HETATM 1223  O   HOH A  92       5.813  -8.236  25.969  1.00 17.19           O  
+HETATM 1224  O   HOH A  93       3.980  -8.424  27.915  1.00 45.26           O  
+HETATM 1225  O   HOH A  95       3.003  -4.890  32.601  1.00 33.05           O  
+HETATM 1226  O   HOH A 100       5.954   2.959  30.728  1.00 22.71           O  
+HETATM 1227  O   HOH A 102       1.427   8.064  29.137  1.00 20.32           O  
+HETATM 1228  O   HOH A 103       0.069  10.278  28.671  1.00 26.96           O  
+HETATM 1229  O   HOH A 107      11.731   7.616  14.957  1.00 35.32           O  
+HETATM 1230  O   HOH A 109      17.752  -1.488  16.332  1.00 16.28           O  
+HETATM 1231  O   HOH A 110      18.300  -2.617  13.629  1.00 36.31           O  
+HETATM 1232  O   HOH A 112      15.384  -2.693  21.288  1.00 15.66           O  
+HETATM 1233  O   HOH A 115      16.975   6.559   9.588  1.00 22.37           O  
+HETATM 1234  O   HOH A 133      -6.399   4.993  27.632  1.00 21.16           O  
+HETATM 1235  O   HOH A 134      -5.284   2.494  25.502  1.00 25.98           O  
+HETATM 1236  O   HOH A 145       2.424   7.060  31.524  1.00 39.18           O  
+HETATM 1237  O   HOH A 146       0.953   5.800  35.902  1.00 17.56           O  
+HETATM 1238  O   HOH A 147      -3.357   8.477  35.074  1.00 22.51           O  
+HETATM 1239  O   HOH A 156      -5.784   2.630  28.262  1.00 18.81           O  
+HETATM 1240  O   HOH B   8      -9.278  -3.873  12.531  1.00 22.08           O  
+HETATM 1241  O   HOH B   9      -6.054  -3.575  12.922  1.00 20.44           O  
+HETATM 1242  O   HOH B  10      -7.885  -7.604  15.173  1.00 30.12           O  
+HETATM 1243  O   HOH B  27      -6.667   7.348  17.580  1.00 13.20           O  
+HETATM 1244  O   HOH B  28      -4.717  10.722  19.158  1.00 30.06           O  
+HETATM 1245  O   HOH B  29      -3.967  13.263  17.705  1.00 25.97           O  
+HETATM 1246  O   HOH B  30      -1.825  15.769  20.641  1.00 20.02           O  
+HETATM 1247  O   HOH B  32       2.720  14.979  18.192  1.00 24.77           O  
+HETATM 1248  O   HOH B  54      13.497   9.788  22.847  1.00 35.42           O  
+HETATM 1249  O   HOH B  62      -7.871   4.341  15.399  1.00 12.56           O  
+HETATM 1250  O   HOH B  63      -6.931   3.498  11.850  1.00 18.53           O  
+HETATM 1251  O   HOH B  68      -2.253   9.110  10.742  1.00 10.27           O  
+HETATM 1252  O   HOH B  70       5.655   5.872  19.345  1.00 11.56           O  
+HETATM 1253  O   HOH B  76       9.022  17.022  27.006  1.00 14.84           O  
+HETATM 1254  O   HOH B  80       9.413  10.924  23.743  1.00 29.22           O  
+HETATM 1255  O   HOH B  81      12.505  11.357  27.184  1.00 46.92           O  
+HETATM 1256  O   HOH B  82      14.659   9.548  25.447  1.00 33.65           O  
+HETATM 1257  O   HOH B  83      16.156   6.560  26.149  1.00 15.70           O  
+HETATM 1258  O   HOH B  90       9.517  12.777  32.170  1.00 36.80           O  
+HETATM 1259  O   HOH B  98       9.400   8.568  35.268  1.00 53.84           O  
+HETATM 1260  O   HOH B  99      10.971   2.032  31.701  1.00 28.16           O  
+HETATM 1261  O   HOH B 101       4.201   8.892  28.546  1.00 37.32           O  
+HETATM 1262  O   HOH B 113      13.862  -2.993  25.084  1.00 22.26           O  
+HETATM 1263  O   HOH B 114      -6.955  -0.760  22.674  1.00 11.33           O  
+HETATM 1264  O   HOH B 131      21.061  -3.230  30.793  1.00 31.30           O  
+HETATM 1265  O   HOH B 132      19.823   2.765  30.305  1.00 11.63           O  
+HETATM 1266  O   HOH B 135      14.316   6.844  23.216  1.00 20.88           O  
+HETATM 1267  O   HOH B 136      11.398   7.588  22.429  1.00 16.80           O  
+HETATM 1268  O   HOH B 137      11.613   9.932  25.264  1.00 18.92           O  
+HETATM 1269  O   HOH B 138      10.404   2.565  29.530  1.00 35.68           O  
+HETATM 1270  O   HOH B 139      12.031  -0.283  31.059  1.00 43.63           O  
+HETATM 1271  O   HOH B 152      -4.349  -0.647  22.381  1.00 11.16           O  
+HETATM 1272  O   HOH B 153      -7.370   0.974  24.524  1.00 18.00           O  
+HETATM 1273  O   HOH B 154      -9.365   2.262  25.807  1.00 13.32           O  
+HETATM 1274  O   HOH B 155      21.374   0.314  27.844  1.00 19.80           O  
+HETATM 1275  O   HOH B 157     -12.076   5.580  24.546  1.00 23.50           O  
+HETATM 1276  O   HOH B 158      12.734  -1.437  26.691  1.00 39.94           O  
+HETATM 1277  O   HOH B 159      10.804  -4.644  30.943  1.00 40.09           O  
+HETATM 1278  O   HOH C  95      13.379  -9.074   3.257  1.00 48.86           O  
+HETATM 1279  O   HOH C  96      17.885  -5.923   5.663  1.00 23.42           O  
+HETATM 1280  O   HOH C  97      17.209  -2.844   6.112  1.00 27.49           O  
+HETATM 1281  O   HOH C  98      20.127  -0.971   7.422  1.00 20.39           O  
+HETATM 1282  O   HOH C  99      19.547  -3.636   9.249  1.00 19.47           O  
+HETATM 1283  O   HOH C 100      -6.500  -2.753  19.496  1.00 15.15           O  
+HETATM 1284  O   HOH C 101      -3.854  -2.388  19.880  1.00 18.78           O  
+HETATM 1285  O   HOH C 102      -3.790  -1.923  17.463  1.00 13.03           O  
+HETATM 1286  O   HOH C 103      -2.026  -0.617  15.665  1.00 10.30           O  
+HETATM 1287  O   HOH C 104      -2.384  -4.715  20.146  1.00 10.46           O  
+HETATM 1288  O   HOH C 105      -2.139  -4.781  23.192  1.00 19.39           O  
+HETATM 1289  O   HOH C 106       2.688  -3.470  21.765  1.00 18.69           O  
+HETATM 1290  O   HOH C 107       0.012  -0.087  25.833  1.00 21.85           O  
+HETATM 1291  O   HOH C 108       8.430   4.164  -7.002  1.00  8.77           O  
+HETATM 1292  O   HOH C 109       0.424  15.870  17.776  1.00 30.46           O  
+HETATM 1293  O   HOH C 110       3.383  14.225   9.282  1.00  9.55           O  
+HETATM 1294  O   HOH C 111       1.015  14.139   7.405  1.00 10.78           O  
+HETATM 1295  O   HOH C 112      -5.483 -13.870  -2.575  1.00 11.38           O  
+HETATM 1296  O   HOH C 113      -5.606 -13.953  -0.265  1.00 16.05           O  
+HETATM 1297  O   HOH C 114      -4.550 -16.308  -1.822  1.00 10.94           O  
+HETATM 1298  O   HOH C 115      -4.944 -16.921   0.633  1.00 19.48           O  
+HETATM 1299  O   HOH C 116      -2.727 -17.831   2.206  1.00 14.93           O  
+HETATM 1300  O   HOH C 117       6.863   7.706  -7.748  1.00 17.41           O  
+HETATM 1301  O   HOH C 118     -10.014 -17.138   2.857  1.00 14.59           O  
+HETATM 1302  O   HOH C 119     -11.276 -11.619  -2.396  1.00 27.63           O  
+HETATM 1303  O   HOH C 120      -8.189 -10.764  -3.411  1.00 22.89           O  
+HETATM 1304  O   HOH C 121      12.313  12.906   6.183  1.00 27.07           O  
+HETATM 1305  O   HOH C 122      12.889   7.986   6.738  1.00 18.75           O  
+HETATM 1306  O   HOH C 123      13.484   4.776   5.829  1.00 15.99           O  
+HETATM 1307  O   HOH C 124       9.941   9.500  13.550  1.00  7.66           O  
+HETATM 1308  O   HOH C 125       1.990 -12.613  19.250  1.00 26.67           O  
+HETATM 1309  O   HOH C 126       6.262  -9.287  16.028  1.00 41.21           O  
+HETATM 1310  O   HOH C 127      -9.708  10.635  16.305  1.00 34.70           O  
+HETATM 1311  O   HOH C 128      18.597   4.867  10.375  1.00 25.57           O  
+HETATM 1312  O   HOH C 129     -12.480   5.750   3.557  1.00 23.56           O  
+HETATM 1313  O   HOH C 130     -10.583  13.732   6.312  1.00 36.90           O  
+HETATM 1314  O   HOH C 131       7.228  11.451   8.758  1.00 19.80           O  
+HETATM 1315  O   HOH C 132       0.379   5.794  15.738  1.00 16.33           O  
+HETATM 1316  O   HOH C 133       8.428  -8.872  16.199  1.00 21.07           O  
+HETATM 1317  O   HOH C 134      15.263  -5.902  14.948  1.00 25.50           O  
+HETATM 1318  O   HOH C 135      13.525  -8.670  20.288  1.00 32.94           O  
+HETATM 1319  O   HOH C 136      -1.744 -16.725  10.692  1.00 31.86           O  
+HETATM 1320  O   HOH C 137      -1.522 -16.334   4.190  1.00 17.68           O  
+HETATM 1321  O   HOH C 138       3.714   8.310  -4.655  1.00 18.37           O  
+HETATM 1322  O   HOH C 139      -0.332   5.189  -4.451  1.00 36.99           O  
+HETATM 1323  O   HOH C 140       5.556 -17.349   5.418  1.00 35.57           O  
+HETATM 1324  O   HOH C 141       3.109 -11.077  15.290  1.00 27.55           O  
+HETATM 1325  O   HOH C 142     -16.325  15.816  12.838  1.00 37.80           O  
+HETATM 1326  O   HOH C 143       9.725  -4.030  -8.587  1.00 37.10           O  
+HETATM 1327  O   HOH C 144      14.196   4.993  -2.118  1.00 18.41           O  
+HETATM 1328  O   HOH C 145      12.901 -12.258  12.578  1.00 21.05           O  
+HETATM 1329  O   HOH C 146      -3.438 -11.800   9.184  1.00 26.75           O  
+HETATM 1330  O   HOH C 147      -4.329 -11.347  19.703  1.00 29.29           O  
+HETATM 1331  O   HOH C 148      11.193   3.384  15.931  1.00 24.01           O  
+HETATM 1332  O   HOH C 149      15.413  -4.345  12.751  1.00 16.66           O  
+HETATM 1333  O   HOH C 150     -12.354   3.244   3.826  1.00 27.34           O  
+HETATM 1334  O   HOH C 151     -10.330   0.950   1.379  1.00 40.89           O  
+HETATM 1335  O   HOH C 152      -9.380  -2.784   0.235  1.00 35.41           O  
+HETATM 1336  O   HOH C 153      -0.533  -5.385  -1.801  1.00 27.14           O  
+HETATM 1337  O   HOH C 154       1.050  -6.028  -3.872  1.00 22.21           O  
+HETATM 1338  O   HOH C 155       2.846 -10.037  -3.659  1.00 20.20           O  
+HETATM 1339  O   HOH C 156      -4.774  15.348   5.709  1.00 21.05           O  
+HETATM 1340  O   HOH C 157      -3.471  16.121   7.903  1.00 25.27           O  
+HETATM 1341  O   HOH C 158       4.970 -11.026  -0.642  1.00 19.31           O  
+HETATM 1342  O   HOH C 159      10.184 -10.157  -3.778  1.00 27.39           O  
+HETATM 1343  O   HOH C 160      11.462 -14.418  -1.832  1.00 23.66           O  
+HETATM 1344  O   HOH C 161       7.062  -4.071  -4.220  1.00 13.87           O  
+HETATM 1345  O   HOH C 162       5.256  -2.369  -4.377  1.00 16.63           O  
+HETATM 1346  O   HOH C 163       5.147  -0.010  -3.468  1.00 16.67           O  
+HETATM 1347  O   HOH C 164       3.207  -3.759  -8.095  1.00 25.03           O  
+HETATM 1348  O   HOH C 165      -2.444   4.281  -2.781  1.00 40.99           O  
+HETATM 1349  O   HOH C 166       3.145 -14.270   5.856  1.00 16.39           O  
+HETATM 1350  O   HOH C 167      -1.289 -10.739   8.287  1.00 15.54           O  
+HETATM 1351  O   HOH C 168      11.333  11.670   3.863  1.00 19.16           O  
+HETATM 1352  O   HOH C 169      15.475 -13.570  14.354  1.00 18.27           O  
+HETATM 1353  O   HOH C 170      11.543   9.093   4.178  1.00 11.87           O  
+HETATM 1354  O   HOH C 171      17.742  -5.157   3.056  1.00 30.99           O  
+HETATM 1355  O   HOH C 172     -12.118  -2.974   6.319  1.00 31.41           O  
+HETATM 1356  O   HOH C 173      21.166  -5.689   8.683  1.00 34.61           O  
+HETATM 1357  O   HOH C 174       0.872  -5.200  -6.659  1.00 43.14           O  
+HETATM 1358  O   HOH C 175       4.826  -2.150  -7.022  1.00 32.59           O  
+HETATM 1359  O   HOH C 176      -5.366  -5.513  25.888  1.00 36.08           O  
+CONECT  355 1198                                                                
+CONECT 1163 1199                                                                
+CONECT 1198  355 1248 1256 1266                                                 
+CONECT 1198 1267 1268                                                           
+CONECT 1199 1163 1301                                                           
+CONECT 1248 1198                                                                
+CONECT 1256 1198                                                                
+CONECT 1266 1198                                                                
+CONECT 1267 1198                                                                
+CONECT 1268 1198                                                                
+CONECT 1301 1199                                                                
+MASTER      286    0    2    5    4    0    3    6 1356    3   11   10          
+END                                                                             


### PR DESCRIPTION

```shell
cargo test -p pdbtbx run_pdbs -- --nocapture
```

```txt
Working on file: /Users/zcpowers/Documents/Projects/pdbtbx/example-pdbs/1BC8.pdb
LooseWarning: SEQRES inconsistent residues
    ╷
342 │ SEQRES   1 A   10   DT  DA  DC  DC  DG  DG  DA  DA  DG  DT
    ·                    ─── ─── ─── ─── ─── ─── ─── ─── ─── ───
    ╰SEQRES definition
  ╷
1 │  DA DA DC DT DT DC DC DG DG DT
  ╰Residues found in ATOM definitions
The residues as defined in the SEQRES records do not match with the found residues, see above for details.

LooseWarning: SEQRES inconsistent residues
    ╷
342 │ SEQRES   1 A   10   DT  DA  DC  DC  DG  DG  DA  DA  DG  DT
    ·                    ─── ─── ─── ─── ─── ─── ─── ─── ─── ───
    ╰SEQRES definition
  ╷
1 │  DT DA DC DC DG DG DA DA DG DT
  ╰Residues found in ATOM definitions
The residues as defined in the SEQRES records do not match with the found residues, see above for details.

Found 1356 atoms, in 275 residues, in 3 chains, in 1 models it all took 2 ms
PDB parsed
Set values
Counted for averages
Found averages
Average B factor: Total: 16.988, Backbone: 15.760, Sidechains: 17.452
```