### PR TITLE
Basic changes to support (only) pdbqt

### DIFF
--- a/src/read/mmcif/parser.rs
+++ b/src/read/mmcif/parser.rs
@@ -572,36 +572,38 @@ fn parse_atoms(input: &Loop, pdb: &mut PDB, options: &ReadOptions) -> Option<Vec
                 context.clone(),
             ))
         }
-        if let Some(mut atom) = Atom::new(
-            hetero,
-            serial_number,
-            name,
-            pos_x,
-            pos_y,
-            pos_z,
-            occupancy,
-            b_factor,
-            element,
-            charge,
-        ) {
-            if let Some(matrix) = aniso {
-                atom.set_anisotropic_temperature_factors(matrix);
-            }
+        // not used for .pdbqt
+        todo!()
+        // if let Some(mut atom) = Atom::new(
+        //     hetero,
+        //     serial_number,
+        //     name,
+        //     pos_x,
+        //     pos_y,
+        //     pos_z,
+        //     occupancy,
+        //     b_factor,
+        //     element,
+        //     charge,
+        // ) {
+        //     if let Some(matrix) = aniso {
+        //         atom.set_anisotropic_temperature_factors(matrix);
+        //     }
 
-            model.add_atom(
-                atom,
-                chain_name,
-                (residue_number, insertion_code.as_deref()),
-                (residue_name, alt_loc.as_deref()),
-            );
-        } else {
-            errors.push(PDBError::new(
-                ErrorLevel::InvalidatingError,
-                "Atom definition incorrect",
-                "The atom name and element should only contain valid characters.",
-                context.clone(),
-            ))
-        }
+        //     model.add_atom(
+        //         atom,
+        //         chain_name,
+        //         (residue_number, insertion_code.as_deref()),
+        //         (residue_name, alt_loc.as_deref()),
+        //     );
+        // } else {
+        //     errors.push(PDBError::new(
+        //         ErrorLevel::InvalidatingError,
+        //         "Atom definition incorrect",
+        //         "The atom name and element should only contain valid characters.",
+        //         context.clone(),
+        //     ))
+        // }
     }
     if !errors.is_empty() {
         Some(errors)

--- a/src/read/pdb/lexitem.rs
+++ b/src/read/pdb/lexitem.rs
@@ -28,6 +28,7 @@ pub enum LexItem {
     /// * segment id
     /// * element
     /// * charge
+    /// * autodock type
     Atom(
         bool,
         usize,
@@ -44,7 +45,8 @@ pub enum LexItem {
         f64,
         String,
         String,
-        isize,
+        f32,
+        String,
     ),
     /// An Anisou record with all its information, including the deprecated and rarely used fields.
     /// * serial number

--- a/src/read/pdb/parser.rs
+++ b/src/read/pdb/parser.rs
@@ -155,6 +155,7 @@ where
                         _,
                         element,
                         charge,
+                        autodock_type,
                     ) => {
                         if options.discard_hydrogens & (element == "H") {
                             continue;
@@ -184,6 +185,7 @@ where
                             b,
                             element,
                             charge,
+                            autodock_type,
                         )
                         .expect("Invalid characters in atom creation");
                         let conformer_id = (residue_name.as_str(), alt_loc.as_deref());

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -160,17 +160,6 @@ pub fn validate_pdb(pdb: &PDB) -> Vec<PDBError> {
                                 Context::None,
                             ));
                         }
-                        if atom.charge() > 9 || atom.charge() < -9 {
-                            errors.push(PDBError::new(
-                                ErrorLevel::LooseWarning,
-                                "Atom charge out of bounds",
-                                format!(
-                                "Atom {} has a charge which is out of bounds, max is 9 min is -9.",
-                                atom.serial_number()
-                            ),
-                                Context::None,
-                            ));
-                        }
                         if atom.occupancy() > 999.99 {
                             errors.push(PDBError::new(
                                 ErrorLevel::LooseWarning,


### PR DESCRIPTION
This is just a FYI PR (by no means intended to be merged!) to get a first idea of the changes that would be needed to support pdbqt (see https://github.com/douweschulte/pdbtbx/issues/134)

With these changes, pdbqt files can be parsed. It currently breaks the parsing of the other files.

It's difficult to say whether the complexity of adding pdbqt support (properly) is justified. It works for me to simply use this fork, but it's a lot of duplicated code.