### PR TITLE
fix: correct chain indexing so _atom_site.label_asym_id starts at 'A'

### DIFF
--- a/src/save/mmcif.rs
+++ b/src/save/mmcif.rs
@@ -305,7 +305,6 @@ _atom_site.aniso_U[3][3]"
     for model in pdb.models() {
         let mut chain_index = 0;
         for chain in model.chains() {
-            chain_index += 1;
             for (residue_index, residue) in chain.residues().enumerate() {
                 for conformer in residue.conformers() {
                     for atom in conformer.atoms() {
@@ -320,7 +319,7 @@ _atom_site.aniso_U[3][3]"
                             conformer.name().to_string(), // Residue name
                             number_to_base26(chain_index), // Label Chain name, defined to be without gaps
                             chain.id().to_string(),        // Auth Chain name
-                            chain_index.to_string(),       // Entity ID, using chain serial number
+                            (chain_index + 1).to_string(),       // Entity ID, using chain serial number
                             (residue_index + 1).to_string(), // `label_seq_id` defined to be [1-N] where N is the index
                             residue.serial_number().to_string(), // Residue serial number
                             residue.insertion_code().unwrap_or(".").to_string(), // Insertion code
@@ -364,6 +363,7 @@ _atom_site.aniso_U[3][3]"
                     }
                 }
             }
+        chain_index += 1;
         }
     }
     if !lines.is_empty() {


### PR DESCRIPTION
Fixed a bug when saving pdb as mmCIF where label indexing was offset:
- Issue: `chain_index` was incremented at the start of the loop, causing the first chain being assigned index 1 (label_asym_id 'B')
- Fix: increment `chain_index` at the end of the loop so `label_asym_id` correctly starts at 'A' while keeping `label_entity_id` starting at 1